### PR TITLE
geom_alt props

### DIFF
--- a/data/421/203/305/421203305.geojson
+++ b/data/421/203/305/421203305.geojson
@@ -166,6 +166,9 @@
     },
     "wof:country":"AO",
     "wof:created":1459010146,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"9eeef97f1c35b52c2b9d3ea05e950cdb",
     "wof:hierarchy":[
         {
@@ -177,7 +180,7 @@
         }
     ],
     "wof:id":421203305,
-    "wof:lastmodified":1561790900,
+    "wof:lastmodified":1582355928,
     "wof:name":"Chitado",
     "wof:parent_id":1108799849,
     "wof:placetype":"locality",

--- a/data/856/322/81/85632281.geojson
+++ b/data/856/322/81/85632281.geojson
@@ -955,7 +955,8 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso"
+        "meso",
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1009,6 +1010,11 @@
     },
     "wof:country":"AO",
     "wof:country_alpha3":"AGO",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "meso",
+        "naturalearth"
+    ],
     "wof:geomhash":"7f24991a733f2c31c4ba8f17aa909da8",
     "wof:hierarchy":[
         {
@@ -1023,7 +1029,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566585999,
+    "wof:lastmodified":1582355902,
     "wof:name":"Angola",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/322/81/85632281.geojson
+++ b/data/856/322/81/85632281.geojson
@@ -955,8 +955,7 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "naturalearth"
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"wk",
@@ -1029,7 +1028,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1582355902,
+    "wof:lastmodified":1583237899,
     "wof:name":"Angola",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/676/45/85667645.geojson
+++ b/data/856/676/45/85667645.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Lunda Norte Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ffe1d06afd1f79cbd3a017b9610e7e1b",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586004,
+    "wof:lastmodified":1582355906,
     "wof:name":"Lunda Norte",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/51/85667651.geojson
+++ b/data/856/676/51/85667651.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Lunda Sul Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e170613e9dc401b165e455959d91b59c",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586003,
+    "wof:lastmodified":1582355905,
     "wof:name":"Lunda Sul",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/53/85667653.geojson
+++ b/data/856/676/53/85667653.geojson
@@ -302,6 +302,9 @@
         "wk:page":"Malanje Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2c1fc75c5599f78d0f337cd8b9efdfd0",
     "wof:hierarchy":[
         {
@@ -317,7 +320,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586006,
+    "wof:lastmodified":1582355907,
     "wof:name":"Malanje",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/57/85667657.geojson
+++ b/data/856/676/57/85667657.geojson
@@ -327,6 +327,9 @@
         "wk:page":"Bengo Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b516c20a27e3b96feaead58599a15eba",
     "wof:hierarchy":[
         {
@@ -342,7 +345,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586002,
+    "wof:lastmodified":1582355905,
     "wof:name":"Bengo",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/59/85667659.geojson
+++ b/data/856/676/59/85667659.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Cuanza Norte Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eb14b23c979bbf5dc4898068b3ca934d",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586001,
+    "wof:lastmodified":1582355904,
     "wof:name":"Cuanza Norte",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/65/85667665.geojson
+++ b/data/856/676/65/85667665.geojson
@@ -313,6 +313,9 @@
         "wk:page":"Cuanza Sul Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"b78055bfcc0d4a51b81130b9e6848e15",
     "wof:hierarchy":[
         {
@@ -328,7 +331,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586006,
+    "wof:lastmodified":1582355907,
     "wof:name":"Cuanza Sul",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/69/85667669.geojson
+++ b/data/856/676/69/85667669.geojson
@@ -330,6 +330,9 @@
         "wk:page":"Luanda Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4b37df120a62de015219d58720344fc8",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586003,
+    "wof:lastmodified":1582355905,
     "wof:name":"Luanda",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/73/85667673.geojson
+++ b/data/856/676/73/85667673.geojson
@@ -322,6 +322,9 @@
         "wk:page":"U\u00edge Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"179fcdc944e0f5355a93b26b0a3231b2",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586004,
+    "wof:lastmodified":1582355906,
     "wof:name":"U\u00edge",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/77/85667677.geojson
+++ b/data/856/676/77/85667677.geojson
@@ -316,6 +316,9 @@
         "wk:page":"Zaire Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e3d06ec387bc1df8452ff9791ca07587",
     "wof:hierarchy":[
         {
@@ -331,7 +334,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586007,
+    "wof:lastmodified":1582355907,
     "wof:name":"Zaire",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/83/85667683.geojson
+++ b/data/856/676/83/85667683.geojson
@@ -365,6 +365,9 @@
         "wk:page":"Cabinda Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"81691433ba35302f99f5dcf6e4c98911",
     "wof:hierarchy":[
         {
@@ -380,7 +383,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586007,
+    "wof:lastmodified":1582355907,
     "wof:name":"Cabinda",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/87/85667687.geojson
+++ b/data/856/676/87/85667687.geojson
@@ -326,6 +326,9 @@
         "wk:page":"Bi\u00e9 Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7bf289d79aa27e2a73437dd6242ba3bc",
     "wof:hierarchy":[
         {
@@ -341,7 +344,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586005,
+    "wof:lastmodified":1582355906,
     "wof:name":"Bi\u00e9",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/91/85667691.geojson
+++ b/data/856/676/91/85667691.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Benguela Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"975bfee082ff948524431c6e0d67e69c",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586005,
+    "wof:lastmodified":1582355906,
     "wof:name":"Benguela",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/95/85667695.geojson
+++ b/data/856/676/95/85667695.geojson
@@ -324,6 +324,9 @@
         "wk:page":"Cuando Cubango Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"d45eabed69cc5bb178dbe987d96a46d1",
     "wof:hierarchy":[
         {
@@ -339,7 +342,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586001,
+    "wof:lastmodified":1582355904,
     "wof:name":"Cuando Cubango",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/01/85667701.geojson
+++ b/data/856/677/01/85667701.geojson
@@ -309,6 +309,9 @@
         "wk:page":"Cunene Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6d098e18c4990c90f5622a323c89899e",
     "wof:hierarchy":[
         {
@@ -324,7 +327,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586010,
+    "wof:lastmodified":1582355909,
     "wof:name":"Cunene",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/05/85667705.geojson
+++ b/data/856/677/05/85667705.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Huambo Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3bc208ad618ca61cb4d7f40d99c68008",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586008,
+    "wof:lastmodified":1582355908,
     "wof:name":"Huambo",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/07/85667707.geojson
+++ b/data/856/677/07/85667707.geojson
@@ -322,6 +322,9 @@
         "wk:page":"Hu\u00edla Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec0a359efc3f7c3362217ee28891c26f",
     "wof:hierarchy":[
         {
@@ -337,7 +340,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586010,
+    "wof:lastmodified":1582355909,
     "wof:name":"Hu\u00edla",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/11/85667711.geojson
+++ b/data/856/677/11/85667711.geojson
@@ -321,6 +321,9 @@
         "wk:page":"Moxico Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c06df3e7364fc59a55b14ca56074865f",
     "wof:hierarchy":[
         {
@@ -336,7 +339,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586008,
+    "wof:lastmodified":1582355908,
     "wof:name":"Moxico",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/17/85667717.geojson
+++ b/data/856/677/17/85667717.geojson
@@ -315,6 +315,9 @@
         "wk:page":"Namibe Province"
     },
     "wof:country":"AO",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"57a46152812eabd32f39c91691261b90",
     "wof:hierarchy":[
         {
@@ -330,7 +333,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1566586009,
+    "wof:lastmodified":1582355908,
     "wof:name":"Namibe",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/890/432/155/890432155.geojson
+++ b/data/890/432/155/890432155.geojson
@@ -576,6 +576,10 @@
     },
     "wof:country":"AO",
     "wof:created":1469051930,
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "unknown"
+    ],
     "wof:geomhash":"4f030e83f76c68d66ed4825561335e72",
     "wof:hierarchy":[
         {
@@ -587,7 +591,7 @@
         }
     ],
     "wof:id":890432155,
-    "wof:lastmodified":1574291827,
+    "wof:lastmodified":1582355929,
     "wof:name":"Luanda",
     "wof:parent_id":1108799745,
     "wof:placetype":"locality",

--- a/data/890/444/245/890444245.geojson
+++ b/data/890/444/245/890444245.geojson
@@ -252,6 +252,9 @@
     },
     "wof:country":"AO",
     "wof:created":1469052461,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2522b83709588b03a873cc0c9945cdec",
     "wof:hierarchy":[
         {
@@ -263,7 +266,7 @@
         }
     ],
     "wof:id":890444245,
-    "wof:lastmodified":1566586987,
+    "wof:lastmodified":1582355929,
     "wof:name":"Caxito",
     "wof:parent_id":1108799875,
     "wof:placetype":"locality",

--- a/data/890/444/579/890444579.geojson
+++ b/data/890/444/579/890444579.geojson
@@ -333,6 +333,9 @@
     },
     "wof:country":"AO",
     "wof:created":1469052474,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"43ba756ec18f903aeb24c27281081f9b",
     "wof:hierarchy":[
         {
@@ -344,7 +347,7 @@
         }
     ],
     "wof:id":890444579,
-    "wof:lastmodified":1566586987,
+    "wof:lastmodified":1582355929,
     "wof:name":"Huambo",
     "wof:parent_id":1108799931,
     "wof:placetype":"locality",

--- a/data/890/444/581/890444581.geojson
+++ b/data/890/444/581/890444581.geojson
@@ -334,6 +334,9 @@
     },
     "wof:country":"AO",
     "wof:created":1469052474,
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"734261cd4a694e5d072b00ded451c2d3",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         }
     ],
     "wof:id":890444581,
-    "wof:lastmodified":1566586987,
+    "wof:lastmodified":1582355929,
     "wof:name":"Benguela",
     "wof:parent_id":1108799959,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.