### PR TITLE
ao concordances, placetype local, and more

### DIFF
--- a/data/110/879/959/7/1108799597.geojson
+++ b/data/110/879/959/7/1108799597.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.676775,
-    "geom:area_square_m":7986877026.523408,
+    "geom:area_square_m":7986876876.083797,
     "geom:bbox":"18.865298,-17.910504,20.050544,-16.761924",
     "geom:latitude":-17.366749,
     "geom:longitude":19.42101,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.CC.CA",
         "wd:id":"Q1619493"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985219,
-    "wof:geomhash":"a65863cd1d9a18b4bd810bb0874040d5",
+    "wof:geomhash":"dd806e6c90ea0b6a849a1cf123b9df37",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799597,
-    "wof:lastmodified":1690850264,
+    "wof:lastmodified":1695886656,
     "wof:name":"Kalai",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/959/9/1108799599.geojson
+++ b/data/110/879/959/9/1108799599.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.479291,
-    "geom:area_square_m":5881774684.897603,
+    "geom:area_square_m":5881774581.386789,
     "geom:bbox":"16.001952,-7.603533,17.109267,-6.669876",
     "geom:latitude":-7.042016,
     "geom:longitude":16.582479,
@@ -56,7 +56,7 @@
     "wof:concordances":{},
     "wof:country":"AO",
     "wof:created":1483985222,
-    "wof:geomhash":"ee6c4ba501de308655e2ab8ffe65aa31",
+    "wof:geomhash":"0a319985baa72be36c5621a93db6dc29",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -66,7 +66,7 @@
         }
     ],
     "wof:id":1108799599,
-    "wof:lastmodified":1627521477,
+    "wof:lastmodified":1695887499,
     "wof:name":"Milunga",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/960/1/1108799601.geojson
+++ b/data/110/879/960/1/1108799601.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.691183,
-    "geom:area_square_m":8267361335.511385,
+    "geom:area_square_m":8267361745.223233,
     "geom:bbox":"12.56298,-15.212517,13.691323,-14.173961",
     "geom:latitude":-14.6843,
     "geom:longitude":13.141314,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.NA.BI",
         "wd:id":"Q950638"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985224,
-    "wof:geomhash":"1fe5856837eac3758c030f5f49c1f93b",
+    "wof:geomhash":"cb87c14c39fab0df7d92c38d75f05974",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799601,
-    "wof:lastmodified":1690850267,
+    "wof:lastmodified":1695886656,
     "wof:name":"Bibala",
     "wof:parent_id":85667717,
     "wof:placetype":"county",

--- a/data/110/879/960/3/1108799603.geojson
+++ b/data/110/879/960/3/1108799603.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.384667,
-    "geom:area_square_m":4643031168.734549,
+    "geom:area_square_m":4643031807.054938,
     "geom:bbox":"16.658235,-12.890817,17.453573,-12.043001",
     "geom:latitude":-12.537779,
     "geom:longitude":17.022661,
@@ -232,9 +232,10 @@
         "hasc:id":"AO.BI.KU",
         "wd:id":"Q843980"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985225,
-    "wof:geomhash":"41f39706dd52649e6a33a73b490e4e68",
+    "wof:geomhash":"1de35ff0ec98f260686a5b079d833e6e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -244,7 +245,7 @@
         }
     ],
     "wof:id":1108799603,
-    "wof:lastmodified":1690850267,
+    "wof:lastmodified":1695886066,
     "wof:name":"Kuito",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/960/5/1108799605.geojson
+++ b/data/110/879/960/5/1108799605.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.346565,
-    "geom:area_square_m":4152496347.454133,
+    "geom:area_square_m":4152496403.328332,
     "geom:bbox":"14.642367,-14.693484,15.427392,-13.938362",
     "geom:latitude":-14.302737,
     "geom:longitude":15.021929,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.HL.CH",
         "wd:id":"Q956860"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985226,
-    "wof:geomhash":"3cad2362511f096daf48c97aca89954d",
+    "wof:geomhash":"c2fd1b7873ea3a70eca3612926493796",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799605,
-    "wof:lastmodified":1690850267,
+    "wof:lastmodified":1695886656,
     "wof:name":"Chicomba",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/960/7/1108799607.geojson
+++ b/data/110/879/960/7/1108799607.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.145423,
-    "geom:area_square_m":1775672858.527881,
+    "geom:area_square_m":1775672591.379147,
     "geom:bbox":"14.368167,-9.224495,15.047754,-8.852454",
     "geom:latitude":-9.074771,
     "geom:longitude":14.666085,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.CN.GA",
         "wd:id":"Q1619507"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985227,
-    "wof:geomhash":"62aec0ab1c164228ff1fd75d2d14b0c4",
+    "wof:geomhash":"63a40ea35b5a1c4855002af0ff728d6b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799607,
-    "wof:lastmodified":1690850266,
+    "wof:lastmodified":1695886656,
     "wof:name":"Golungo Alto",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/960/9/1108799609.geojson
+++ b/data/110/879/960/9/1108799609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.484063,
-    "geom:area_square_m":5949205311.569567,
+    "geom:area_square_m":5949205906.678161,
     "geom:bbox":"13.814325,-6.870478,14.544481,-5.832283",
     "geom:latitude":-6.310184,
     "geom:longitude":14.181735,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.ZA.MK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985228,
-    "wof:geomhash":"26e14a7ff30258b579d08158d571bc2d",
+    "wof:geomhash":"48ecc1fe44741d59082ade3913b87313",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799609,
-    "wof:lastmodified":1627521477,
+    "wof:lastmodified":1695886722,
     "wof:name":"Mbanza Kongo",
     "wof:parent_id":85667677,
     "wof:placetype":"county",

--- a/data/110/879/961/5/1108799615.geojson
+++ b/data/110/879/961/5/1108799615.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.67725,
-    "geom:area_square_m":8316996071.024427,
+    "geom:area_square_m":8316996516.939755,
     "geom:bbox":"12.624029,-7.066538,14.099657,-6.306931",
     "geom:latitude":-6.706116,
     "geom:longitude":13.361187,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.ZA.TO",
         "wd:id":"Q1620741"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985229,
-    "wof:geomhash":"ee2f0946c95fcd96bc1bbe3f298c3e3f",
+    "wof:geomhash":"a675a92a17961cdd59513d92bf13d10c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799615,
-    "wof:lastmodified":1690850262,
+    "wof:lastmodified":1695886654,
     "wof:name":"Tomboco",
     "wof:parent_id":85667677,
     "wof:placetype":"county",

--- a/data/110/879/961/7/1108799617.geojson
+++ b/data/110/879/961/7/1108799617.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.394663,
-    "geom:area_square_m":4841335950.763066,
+    "geom:area_square_m":4841336048.182205,
     "geom:bbox":"15.579503,-7.530672,16.579624,-6.92031",
     "geom:latitude":-7.224284,
     "geom:longitude":16.055796,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.UI.SP",
         "wd:id":"Q1621564"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985230,
-    "wof:geomhash":"b5ab65f0ebf35fb851836eeb079d5fb3",
+    "wof:geomhash":"86336c93c96169372be55378e253198e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799617,
-    "wof:lastmodified":1690850262,
+    "wof:lastmodified":1695886655,
     "wof:name":"Sanza Pombo",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/961/9/1108799619.geojson
+++ b/data/110/879/961/9/1108799619.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109872,
-    "geom:area_square_m":1343819602.577435,
+    "geom:area_square_m":1343819331.14243,
     "geom:bbox":"14.872886,-8.752725,15.331107,-8.248131",
     "geom:latitude":-8.455964,
     "geom:longitude":15.092257,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.CN.BO",
         "wd:id":"Q2351409"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985232,
-    "wof:geomhash":"50da94c34c644b2d070de37230a1644e",
+    "wof:geomhash":"463294ffbbf9b01f1fcd2d270bbdf235",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799619,
-    "wof:lastmodified":1690850262,
+    "wof:lastmodified":1695886655,
     "wof:name":"Bolongongo",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/962/1/1108799621.geojson
+++ b/data/110/879/962/1/1108799621.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.478917,
-    "geom:area_square_m":5861773099.831313,
+    "geom:area_square_m":5861772634.540392,
     "geom:bbox":"16.54164,-8.725964,17.565135,-7.617681",
     "geom:latitude":-8.169238,
     "geom:longitude":17.11535,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.ML.MR",
         "wd:id":"Q1621369"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985233,
-    "wof:geomhash":"8e01c8910b5e83f7a915500b44f94b71",
+    "wof:geomhash":"6f6f96e490f438ea41aa7335b2c57f90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799621,
-    "wof:lastmodified":1690850247,
+    "wof:lastmodified":1695886649,
     "wof:name":"Marimba",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/962/3/1108799623.geojson
+++ b/data/110/879/962/3/1108799623.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.362655,
-    "geom:area_square_m":40305125118.700142,
+    "geom:area_square_m":40305125134.536171,
     "geom:bbox":"20.307763,-16.160437,22.000278,-12.732271",
     "geom:latitude":-14.203604,
     "geom:longitude":21.321144,
@@ -47,7 +47,7 @@
     "wof:concordances":{},
     "wof:country":"AO",
     "wof:created":1483985234,
-    "wof:geomhash":"dc8f76a45bca4a3151227d105d9ae060",
+    "wof:geomhash":"24ab2d4799e26ed4a7e89198fc119ab5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":1108799623,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695887499,
     "wof:name":"Lumbala-Nguimbo",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/962/5/1108799625.geojson
+++ b/data/110/879/962/5/1108799625.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214111,
-    "geom:area_square_m":2616302142.184469,
+    "geom:area_square_m":2616302221.987225,
     "geom:bbox":"15.262502,-9.179311,15.737276,-8.450331",
     "geom:latitude":-8.807045,
     "geom:longitude":15.496803,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.CN.SC",
         "wd:id":"Q302566"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985235,
-    "wof:geomhash":"7f8cc017b07fb85201db2654acb18461",
+    "wof:geomhash":"66ecdee54fc778be5da1e618b2e96d6c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799625,
-    "wof:lastmodified":1690850247,
+    "wof:lastmodified":1695886649,
     "wof:name":"Samba Caju",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/962/7/1108799627.geojson
+++ b/data/110/879/962/7/1108799627.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.646411,
-    "geom:area_square_m":7919689045.170568,
+    "geom:area_square_m":7919689045.170705,
     "geom:bbox":"16.0620477279,-8.21334454468,17.2776165362,-7.31870514555",
     "geom:latitude":-7.763071,
     "geom:longitude":16.603138,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"AO.ML.MS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985237,
-    "wof:geomhash":"0f6d3d1986bafa84a960cd5bff833b19",
+    "wof:geomhash":"20d06f4fe4dcd49c697476841c4e842f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1108799627,
-    "wof:lastmodified":1566586686,
+    "wof:lastmodified":1695886649,
     "wof:name":"Massango",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/962/9/1108799629.geojson
+++ b/data/110/879/962/9/1108799629.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.473306,
-    "geom:area_square_m":5794874835.366883,
+    "geom:area_square_m":5794874160.856785,
     "geom:bbox":"13.829693,-8.470065,14.731279,-7.622216",
     "geom:latitude":-8.046159,
     "geom:longitude":14.258877,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.BO.NA",
         "wd:id":"Q1617503"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985238,
-    "wof:geomhash":"c6f4ab8cc0ff10e798e3cbdde2448f23",
+    "wof:geomhash":"7469f20860ac6c2a29b049d2516958a8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799629,
-    "wof:lastmodified":1690850247,
+    "wof:lastmodified":1695886649,
     "wof:name":"Nambuangongo",
     "wof:parent_id":85667657,
     "wof:placetype":"county",

--- a/data/110/879/963/3/1108799633.geojson
+++ b/data/110/879/963/3/1108799633.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.247579,
-    "geom:area_square_m":2992824464.971652,
+    "geom:area_square_m":2992824589.134135,
     "geom:bbox":"16.992032,-12.500449,17.512634,-11.769066",
     "geom:latitude":-12.145808,
     "geom:longitude":17.257486,
@@ -118,9 +118,10 @@
         "hasc:id":"AO.BI.CB",
         "wd:id":"Q2341822"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985239,
-    "wof:geomhash":"0b5e6ce85cb64bfdfd49e9cb355d1353",
+    "wof:geomhash":"9954c4dfd626039b8f991edbd90c8adf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108799633,
-    "wof:lastmodified":1690850248,
+    "wof:lastmodified":1695886649,
     "wof:name":"Katabola",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/963/5/1108799635.geojson
+++ b/data/110/879/963/5/1108799635.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.846092,
-    "geom:area_square_m":10260162636.763945,
+    "geom:area_square_m":10260163196.925777,
     "geom:bbox":"15.75345,-11.938549,17.057947,-10.569328",
     "geom:latitude":-11.272067,
     "geom:longitude":16.464874,
@@ -127,9 +127,10 @@
         "hasc:id":"AO.BI.AN",
         "wd:id":"Q2571244"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985240,
-    "wof:geomhash":"5f0455ac4812b96a47104f9e5db341e3",
+    "wof:geomhash":"ad86abe3224d32bfc52db6e61cb3c8a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108799635,
-    "wof:lastmodified":1690850248,
+    "wof:lastmodified":1695886649,
     "wof:name":"Andulo",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/963/7/1108799637.geojson
+++ b/data/110/879/963/7/1108799637.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.297308,
-    "geom:area_square_m":3609899671.562181,
+    "geom:area_square_m":3609899771.849481,
     "geom:bbox":"21.659797,-11.283081,22.323611,-10.587299",
     "geom:latitude":-10.902715,
     "geom:longitude":22.00054,
@@ -145,9 +145,10 @@
         "hasc:id":"AO.MX.LU",
         "wd:id":"Q1872804"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985241,
-    "wof:geomhash":"e617c4b8a04ae4aa2ec45cf5085d7af4",
+    "wof:geomhash":"6ad784f0c74fc9d7ae6568ee7d2cf75a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108799637,
-    "wof:lastmodified":1690850248,
+    "wof:lastmodified":1695886064,
     "wof:name":"Luau",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/963/9/1108799639.geojson
+++ b/data/110/879/963/9/1108799639.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.302706,
-    "geom:area_square_m":15503667650.938923,
+    "geom:area_square_m":15503667956.293816,
     "geom:bbox":"15.197541,-16.401469,17.303389,-15.14351",
     "geom:latitude":-15.744443,
     "geom:longitude":16.141154,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.CU.CV",
         "wd:id":"Q1619947"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985242,
-    "wof:geomhash":"a54147aeeaac19d529fb2eb44c9bbf80",
+    "wof:geomhash":"5f377974f1acbe34ab89164e0198af1e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799639,
-    "wof:lastmodified":1690850248,
+    "wof:lastmodified":1695886649,
     "wof:name":"Kuvelai",
     "wof:parent_id":85667701,
     "wof:placetype":"county",

--- a/data/110/879/964/1/1108799641.geojson
+++ b/data/110/879/964/1/1108799641.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.589427,
-    "geom:area_square_m":43110052334.25518,
+    "geom:area_square_m":43110052178.735664,
     "geom:bbox":"17.946408,-15.003919,20.877975,-12.651726",
     "geom:latitude":-13.749897,
     "geom:longitude":19.535831,
@@ -91,9 +91,10 @@
         "hasc:id":"AO.MX.LZ",
         "wd:id":"Q1620747"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985243,
-    "wof:geomhash":"f188ff1ca8e4b8d1d997205c4790265b",
+    "wof:geomhash":"bbf9fdf04992964ef67541dde84264fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108799641,
-    "wof:lastmodified":1690850249,
+    "wof:lastmodified":1695886650,
     "wof:name":"Luxazes",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/964/3/1108799643.geojson
+++ b/data/110/879/964/3/1108799643.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109792,
-    "geom:area_square_m":1345773011.114549,
+    "geom:area_square_m":1345773139.650299,
     "geom:bbox":"14.847561,-7.792783,15.30065,-7.35385",
     "geom:latitude":-7.568478,
     "geom:longitude":15.087867,
@@ -217,9 +217,10 @@
         "hasc:id":"AO.UI.UI",
         "wd:id":"Q911191"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985245,
-    "wof:geomhash":"a3e9ea2c4727affd8ac38cfcad9646de",
+    "wof:geomhash":"4a0bbfc1b8e03df7abc324a3da73fc9c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -229,7 +230,7 @@
         }
     ],
     "wof:id":1108799643,
-    "wof:lastmodified":1690850250,
+    "wof:lastmodified":1695886650,
     "wof:name":"Uige",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/964/5/1108799645.geojson
+++ b/data/110/879/964/5/1108799645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.52658,
-    "geom:area_square_m":6422148168.03372,
+    "geom:area_square_m":6422147910.142296,
     "geom:bbox":"15.113665,-9.810567,16.246318,-9.128951",
     "geom:latitude":-9.488675,
     "geom:longitude":15.630232,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.ML.CR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985246,
-    "wof:geomhash":"9a883f70d49fb95c01958b75d0e6338d",
+    "wof:geomhash":"2b787688ff228d75f66d60d42f7f236a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799645,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Kakuso",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/964/7/1108799647.geojson
+++ b/data/110/879/964/7/1108799647.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.004337,
-    "geom:area_square_m":12204155390.722086,
+    "geom:area_square_m":12204155854.034395,
     "geom:bbox":"18.47982,-11.458309,19.708806,-9.920776",
     "geom:latitude":-10.663636,
     "geom:longitude":19.211157,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.LS.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985247,
-    "wof:geomhash":"1e199c21f57c73203f7c7603581a9fa3",
+    "wof:geomhash":"8025aa7c82d9790801222e61d8a6de0a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799647,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695886720,
     "wof:name":"Kakolo",
     "wof:parent_id":85667651,
     "wof:placetype":"county",

--- a/data/110/879/965/1/1108799651.geojson
+++ b/data/110/879/965/1/1108799651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.812831,
-    "geom:area_square_m":9863816309.469833,
+    "geom:area_square_m":9863816075.626457,
     "geom:bbox":"17.69362,-11.556244,18.85319,-10.470939",
     "geom:latitude":-11.06685,
     "geom:longitude":18.273732,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.ML.QR",
         "wd:id":"Q1637941"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985248,
-    "wof:geomhash":"38dc9af47e5d81f6b34b50f27adb659c",
+    "wof:geomhash":"392a6fba1d074a669dcae7076382a18e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799651,
-    "wof:lastmodified":1690850245,
+    "wof:lastmodified":1695886648,
     "wof:name":"Kirima",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/965/3/1108799653.geojson
+++ b/data/110/879/965/3/1108799653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.818057,
-    "geom:area_square_m":9939572030.661291,
+    "geom:area_square_m":9939572802.849012,
     "geom:bbox":"14.560919,-11.275191,15.993652,-10.247184",
     "geom:latitude":-10.697215,
     "geom:longitude":15.335955,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.CS.QB",
         "wd:id":"Q602772"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985250,
-    "wof:geomhash":"3d1d498037c73c51c6c714889fa69597",
+    "wof:geomhash":"ffd0952c60c097e88cce827f611d4bc0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799653,
-    "wof:lastmodified":1690850245,
+    "wof:lastmodified":1695886648,
     "wof:name":"Kibala",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/965/5/1108799655.geojson
+++ b/data/110/879/965/5/1108799655.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.450064,
-    "geom:area_square_m":5501876162.174663,
+    "geom:area_square_m":5501875891.945192,
     "geom:bbox":"16.142481,-9.162302,17.071054,-8.25896",
     "geom:latitude":-8.644907,
     "geom:longitude":16.670131,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.ML.CO",
         "wd:id":"Q1621738"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985251,
-    "wof:geomhash":"dc0937a8934afcc8ab49e4660662d97a",
+    "wof:geomhash":"e1690e6ea5d51ae84ac84f188e77d321",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799655,
-    "wof:lastmodified":1690850245,
+    "wof:lastmodified":1695886648,
     "wof:name":"Kahombo",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/965/7/1108799657.geojson
+++ b/data/110/879/965/7/1108799657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094478,
-    "geom:area_square_m":1157843947.672759,
+    "geom:area_square_m":1157843848.468362,
     "geom:bbox":"15.497769,-7.883764,15.832619,-7.428771",
     "geom:latitude":-7.65053,
     "geom:longitude":15.68093,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.UI.PU",
         "wd:id":"Q2361232"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985252,
-    "wof:geomhash":"c06d88bea7e98d8aa7dc7b57d8a305ea",
+    "wof:geomhash":"1e6f556b9aff79ff2bbf33f6c341f08b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799657,
-    "wof:lastmodified":1690850245,
+    "wof:lastmodified":1695886648,
     "wof:name":"Puri",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/965/9/1108799659.geojson
+++ b/data/110/879/965/9/1108799659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164888,
-    "geom:area_square_m":2001732411.608095,
+    "geom:area_square_m":2001732274.944699,
     "geom:bbox":"14.48502,-11.165629,15.069418,-10.617331",
     "geom:latitude":-10.952237,
     "geom:longitude":14.754762,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.CS.EB",
         "wd:id":"Q1619922"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985253,
-    "wof:geomhash":"a1a100211fd55315998bf811ca988b90",
+    "wof:geomhash":"18eabafd83cdbb2241ae497b82e1e529",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799659,
-    "wof:lastmodified":1690850245,
+    "wof:lastmodified":1695886648,
     "wof:name":"Ebo",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/966/1/1108799661.geojson
+++ b/data/110/879/966/1/1108799661.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.916849,
-    "geom:area_square_m":11217061073.839045,
+    "geom:area_square_m":11217060800.528063,
     "geom:bbox":"18.09325,-8.812707,19.486783,-7.916643",
     "geom:latitude":-8.339532,
     "geom:longitude":18.828568,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.LN.CU",
         "wd:id":"Q1620728"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985255,
-    "wof:geomhash":"1fa972fb18919ad4ed16c25c5642876d",
+    "wof:geomhash":"3a50bd51b5500ac54e5a8a3cdbc05147",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799661,
-    "wof:lastmodified":1690850262,
+    "wof:lastmodified":1695886655,
     "wof:name":"Kaungula",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/110/879/966/3/1108799663.geojson
+++ b/data/110/879/966/3/1108799663.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.440708,
-    "geom:area_square_m":5258296928.658195,
+    "geom:area_square_m":5258297335.934946,
     "geom:bbox":"13.405039,-15.727118,14.291839,-14.691392",
     "geom:latitude":-15.21869,
     "geom:longitude":13.864767,
@@ -154,9 +154,10 @@
         "hasc:id":"AO.HL.CB",
         "wd:id":"Q2346746"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985256,
-    "wof:geomhash":"2cf803515e608191418988638e6f2556",
+    "wof:geomhash":"65cb3098134137b71380f735eb9c0548",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108799663,
-    "wof:lastmodified":1690850263,
+    "wof:lastmodified":1695886066,
     "wof:name":"Chibia",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/966/5/1108799665.geojson
+++ b/data/110/879/966/5/1108799665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.756216,
-    "geom:area_square_m":9064198824.152212,
+    "geom:area_square_m":9064198969.30127,
     "geom:bbox":"15.810054,-15.210693,16.748154,-13.331437",
     "geom:latitude":-14.212379,
     "geom:longitude":16.322504,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.HL.KU",
         "wd:id":"Q2343092"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985258,
-    "wof:geomhash":"ace645b9a0109364a06afe2bcf709e64",
+    "wof:geomhash":"4ec1087639f9cdbcc8bf5c1371bafa4c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799665,
-    "wof:lastmodified":1690850263,
+    "wof:lastmodified":1695886655,
     "wof:name":"Kuvango",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/966/9/1108799669.geojson
+++ b/data/110/879/966/9/1108799669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.838851,
-    "geom:area_square_m":10268220115.450645,
+    "geom:area_square_m":10268219243.595459,
     "geom:bbox":"19.349167,-8.954818,20.027507,-7.056324",
     "geom:latitude":-8.120899,
     "geom:longitude":19.69298,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.LN.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985259,
-    "wof:geomhash":"c247296f926e87f5eafb362e77eb4181",
+    "wof:geomhash":"5ae668c5699b68e70445de5bccebcc3d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799669,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Kuilo",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/110/879/967/1/1108799671.geojson
+++ b/data/110/879/967/1/1108799671.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.320265,
-    "geom:area_square_m":3844400997.02317,
+    "geom:area_square_m":3844401258.9277,
     "geom:bbox":"15.344613,-14.428957,16.153929,-13.390162",
     "geom:latitude":-13.883779,
     "geom:longitude":15.738401,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.HL.CP",
         "wd:id":"Q992695"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985265,
-    "wof:geomhash":"bcfaeaef2acf8890805f14a5cb1d28d8",
+    "wof:geomhash":"cd0aa0b382eb54b106b6107bfdbfe401",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799671,
-    "wof:lastmodified":1690850266,
+    "wof:lastmodified":1695886656,
     "wof:name":"Chipindo",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/967/3/1108799673.geojson
+++ b/data/110/879/967/3/1108799673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.554227,
-    "geom:area_square_m":6720045246.211109,
+    "geom:area_square_m":6720044652.535748,
     "geom:bbox":"16.742593,-11.841316,17.536509,-10.739772",
     "geom:latitude":-11.306312,
     "geom:longitude":17.161212,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.BI.NH",
         "wd:id":"Q2342542"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985266,
-    "wof:geomhash":"d372b6e84a96a65adba002b55c56c002",
+    "wof:geomhash":"e5b9c48383ccf4175789bb35204ea001",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799673,
-    "wof:lastmodified":1690850266,
+    "wof:lastmodified":1695886656,
     "wof:name":"Nharea",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/967/5/1108799675.geojson
+++ b/data/110/879/967/5/1108799675.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.214751,
-    "geom:area_square_m":2602973331.668373,
+    "geom:area_square_m":2602974027.527036,
     "geom:bbox":"19.759802,-11.612586,20.742848,-11.202384",
     "geom:latitude":-11.407679,
     "geom:longitude":20.24068,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.MX.CN",
         "wd:id":"Q2351418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985268,
-    "wof:geomhash":"fdd3632aad65844aa9045117f07fc235",
+    "wof:geomhash":"eedc92270a57d3fa9026a057703a6088",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799675,
-    "wof:lastmodified":1690850266,
+    "wof:lastmodified":1695886656,
     "wof:name":"Kamanongue",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/967/7/1108799677.geojson
+++ b/data/110/879/967/7/1108799677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002969,
-    "geom:area_square_m":36273865.430901,
+    "geom:area_square_m":36273916.456453,
     "geom:bbox":"13.27019,-8.864123,13.324788,-8.784052",
     "geom:latitude":-8.822926,
     "geom:longitude":13.300762,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.LU.CZ",
         "wd:id":"Q1005786"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985268,
-    "wof:geomhash":"8bbdd6403fc0a8e2af763b31de7e850f",
+    "wof:geomhash":"49d66d31eb302802f1b17c9501dad9e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799677,
-    "wof:lastmodified":1690850266,
+    "wof:lastmodified":1695886656,
     "wof:name":"Cazenga",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/967/9/1108799679.geojson
+++ b/data/110/879/967/9/1108799679.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.445328,
-    "geom:area_square_m":5474855806.786366,
+    "geom:area_square_m":5474855228.966402,
     "geom:bbox":"13.03403,-6.529392,13.922529,-5.861911",
     "geom:latitude":-6.149954,
     "geom:longitude":13.509343,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.ZA.NO",
         "wd:id":"Q1620885"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985269,
-    "wof:geomhash":"9d48a935e672967d20ab776ffc6135f4",
+    "wof:geomhash":"106cbf5525ee17da787a00c634bd2e90",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799679,
-    "wof:lastmodified":1690850265,
+    "wof:lastmodified":1695886656,
     "wof:name":"Noqui",
     "wof:parent_id":85667677,
     "wof:placetype":"county",

--- a/data/110/879/968/1/1108799681.geojson
+++ b/data/110/879/968/1/1108799681.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.127963,
-    "geom:area_square_m":13651942854.597881,
+    "geom:area_square_m":13651942318.200642,
     "geom:bbox":"17.628793,-12.491306,19.252095,-10.974665",
     "geom:latitude":-11.811374,
     "geom:longitude":18.455478,
@@ -103,9 +103,10 @@
         "hasc:id":"AO.BI.CM",
         "wd:id":"Q931987"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985270,
-    "wof:geomhash":"437156b464f3a213e038121fa3299193",
+    "wof:geomhash":"da6fc70fe03e1bf302e494f4fa85fa27",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108799681,
-    "wof:lastmodified":1690850261,
+    "wof:lastmodified":1695886654,
     "wof:name":"Kuemba",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/968/3/1108799683.geojson
+++ b/data/110/879/968/3/1108799683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.200941,
-    "geom:area_square_m":2465331361.528916,
+    "geom:area_square_m":2465330969.148583,
     "geom:bbox":"14.531161,-7.475205,15.091162,-6.794694",
     "geom:latitude":-7.153286,
     "geom:longitude":14.790858,
@@ -132,9 +132,10 @@
     "wof:concordances":{
         "hasc:id":"AO.UI.SO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985272,
-    "wof:geomhash":"3374951e9d74657cf974ef9014e540e9",
+    "wof:geomhash":"f91e2a55d8f5436b301217263e790733",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -144,7 +145,7 @@
         }
     ],
     "wof:id":1108799683,
-    "wof:lastmodified":1636502535,
+    "wof:lastmodified":1695886065,
     "wof:name":"Songo",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/968/7/1108799687.geojson
+++ b/data/110/879/968/7/1108799687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.759196,
-    "geom:area_square_m":9056307681.060555,
+    "geom:area_square_m":9056307912.938334,
     "geom:bbox":"14.772814,-16.062638,15.572224,-14.447745",
     "geom:latitude":-15.262403,
     "geom:longitude":15.166005,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.HL.MA",
         "wd:id":"Q1016739"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985273,
-    "wof:geomhash":"1de3e9ae1b4a07cf4043ad9b7f54f7ae",
+    "wof:geomhash":"e3d1c46a46927ae7bb0fc664f4ea2d7e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799687,
-    "wof:lastmodified":1690850261,
+    "wof:lastmodified":1695886654,
     "wof:name":"Matala",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/968/9/1108799689.geojson
+++ b/data/110/879/968/9/1108799689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.250053,
-    "geom:area_square_m":3063041805.580545,
+    "geom:area_square_m":3063041941.850163,
     "geom:bbox":"15.663214,-8.226992,16.353254,-7.431708",
     "geom:latitude":-7.838386,
     "geom:longitude":15.957599,
@@ -82,9 +82,10 @@
         "hasc:id":"AO.UI.AC",
         "wd:id":"Q974407"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985275,
-    "wof:geomhash":"2ab9770bb1e77ae63d5a46c9876e1f8f",
+    "wof:geomhash":"26002f7deb466a8085a1716fc0fa2cef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108799689,
-    "wof:lastmodified":1690850260,
+    "wof:lastmodified":1695886654,
     "wof:name":"Kangola",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/969/1/1108799691.geojson
+++ b/data/110/879/969/1/1108799691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.995205,
-    "geom:area_square_m":35781185599.814369,
+    "geom:area_square_m":35781185354.71595,
     "geom:bbox":"17.904312,-16.142594,20.018186,-13.567188",
     "geom:latitude":-14.948073,
     "geom:longitude":18.847191,
@@ -115,9 +115,10 @@
         "hasc:id":"AO.CC.CC",
         "wd:id":"Q899515"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985276,
-    "wof:geomhash":"006cc55c3c6458b5654c941d3f09b5fd",
+    "wof:geomhash":"26ee314e8201a2b9ae5dd4ad7f05a837",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108799691,
-    "wof:lastmodified":1690850269,
+    "wof:lastmodified":1695886657,
     "wof:name":"Kuito Kuanavale",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/969/3/1108799693.geojson
+++ b/data/110/879/969/3/1108799693.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.355545,
-    "geom:area_square_m":16526040142.561293,
+    "geom:area_square_m":16526039688.443726,
     "geom:bbox":"17.335825,-10.669135,18.70089,-8.351692",
     "geom:latitude":-9.602325,
     "geom:longitude":18.022217,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.LN.XM",
         "wd:id":"Q1620892"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985277,
-    "wof:geomhash":"6e91f3c3361a44032894024f298cb5be",
+    "wof:geomhash":"19e11b4a21c8ad24d618d08363bdccb5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799693,
-    "wof:lastmodified":1690850269,
+    "wof:lastmodified":1695886658,
     "wof:name":"Xa-Muteba",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/110/879/969/5/1108799695.geojson
+++ b/data/110/879/969/5/1108799695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.516408,
-    "geom:area_square_m":18547997518.049511,
+    "geom:area_square_m":18547998020.138756,
     "geom:bbox":"19.894491,-9.422387,21.265137,-7.6362",
     "geom:latitude":-8.42203,
     "geom:longitude":20.483795,
@@ -47,7 +47,7 @@
     "wof:concordances":{},
     "wof:country":"AO",
     "wof:created":1483985278,
-    "wof:geomhash":"04a7c9191acfd441040b5ca7fd5d9bed",
+    "wof:geomhash":"6c2b041e3a2719927f4398408c0e07fc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":1108799695,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695887499,
     "wof:name":"Lukapa",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/110/879/969/7/1108799697.geojson
+++ b/data/110/879/969/7/1108799697.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.247718,
-    "geom:area_square_m":2998850100.735198,
+    "geom:area_square_m":2998849527.411596,
     "geom:bbox":"15.905498,-12.035446,16.594123,-11.434034",
     "geom:latitude":-11.753483,
     "geom:longitude":16.20803,
@@ -103,9 +103,10 @@
         "hasc:id":"AO.HM.MU",
         "wd:id":"Q1619956"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985280,
-    "wof:geomhash":"8afc8ea86b8df21415edde182b56f643",
+    "wof:geomhash":"b9867142e3a913153f2197d01065b36e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108799697,
-    "wof:lastmodified":1690850269,
+    "wof:lastmodified":1695886657,
     "wof:name":"Mungo",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/969/9/1108799699.geojson
+++ b/data/110/879/969/9/1108799699.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.630943,
-    "geom:area_square_m":7569853079.459894,
+    "geom:area_square_m":7569852730.906834,
     "geom:bbox":"12.455917,-14.507184,13.64079,-13.511118",
     "geom:latitude":-14.002477,
     "geom:longitude":13.033133,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.NA.CA",
         "wd:id":"Q3651110"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985281,
-    "wof:geomhash":"dafe4d582383336871cb8c621e8b627d",
+    "wof:geomhash":"93ec51be1b7f18fa33adb7113b5eb1ea",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799699,
-    "wof:lastmodified":1690850268,
+    "wof:lastmodified":1695886657,
     "wof:name":"Kamukuio",
     "wof:parent_id":85667717,
     "wof:placetype":"county",

--- a/data/110/879/970/1/1108799701.geojson
+++ b/data/110/879/970/1/1108799701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268505,
-    "geom:area_square_m":3278907189.475031,
+    "geom:area_square_m":3278907110.897305,
     "geom:bbox":"16.036264,-9.358844,16.79653,-8.720312",
     "geom:latitude":-9.036218,
     "geom:longitude":16.460612,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.ML.CN",
         "wd:id":"Q1621354"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985282,
-    "wof:geomhash":"ab072185f509c565631265029335c8bb",
+    "wof:geomhash":"e69b98c323cdf6975c010c56d54e6622",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799701,
-    "wof:lastmodified":1690850253,
+    "wof:lastmodified":1695886651,
     "wof:name":"Kiuaba-Nzoji",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/970/5/1108799705.geojson
+++ b/data/110/879/970/5/1108799705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.562352,
-    "geom:area_square_m":6905619393.772539,
+    "geom:area_square_m":6905619851.621397,
     "geom:bbox":"14.720178,-7.25952,15.624196,-6.161676",
     "geom:latitude":-6.730039,
     "geom:longitude":15.218732,
@@ -103,9 +103,10 @@
         "hasc:id":"AO.UI.DA",
         "wd:id":"Q1621601"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985283,
-    "wof:geomhash":"3d63cb664e82867fbaf28f00a26e9608",
+    "wof:geomhash":"1f452ef3f373eab273235a4d85e2b346",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108799705,
-    "wof:lastmodified":1690850254,
+    "wof:lastmodified":1695886651,
     "wof:name":"Damba",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/970/7/1108799707.geojson
+++ b/data/110/879/970/7/1108799707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.390796,
-    "geom:area_square_m":4706065430.426291,
+    "geom:area_square_m":4706065552.089947,
     "geom:bbox":"14.387909,-13.662471,15.120286,-12.579981",
     "geom:latitude":-13.120239,
     "geom:longitude":14.733954,
@@ -124,9 +124,10 @@
         "hasc:id":"AO.BG.GA",
         "wd:id":"Q1024050"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985285,
-    "wof:geomhash":"cd51c7b348975c4640a330c8afdf56ea",
+    "wof:geomhash":"ec3e806bb2c4084ae467c0b7fab9efd5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108799707,
-    "wof:lastmodified":1690850253,
+    "wof:lastmodified":1695886651,
     "wof:name":"Ganda",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/970/9/1108799709.geojson
+++ b/data/110/879/970/9/1108799709.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.776347,
-    "geom:area_square_m":9373764044.108202,
+    "geom:area_square_m":9373763641.943237,
     "geom:bbox":"17.341767,-13.070232,18.432641,-11.689793",
     "geom:latitude":-12.450102,
     "geom:longitude":17.78431,
@@ -118,9 +118,10 @@
         "hasc:id":"AO.BI.CP",
         "wd:id":"Q1027956"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985287,
-    "wof:geomhash":"471fdcb99122ffd4cf3c33a34937b4ef",
+    "wof:geomhash":"69b20f8fa906f1d1bda9e29dd082f72a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108799709,
-    "wof:lastmodified":1690850253,
+    "wof:lastmodified":1695886651,
     "wof:name":"Kamakupa",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/971/1/1108799711.geojson
+++ b/data/110/879/971/1/1108799711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.391664,
-    "geom:area_square_m":4800592815.233055,
+    "geom:area_square_m":4800592693.267475,
     "geom:bbox":"13.828153,-7.90943,14.965788,-7.28641",
     "geom:latitude":-7.586725,
     "geom:longitude":14.468877,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.UI.AM",
         "wd:id":"Q1620841"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985288,
-    "wof:geomhash":"edf7a79847045535de084e260fca15a8",
+    "wof:geomhash":"f289bd0a4b7585a22125dabaf12faa2a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799711,
-    "wof:lastmodified":1690850256,
+    "wof:lastmodified":1695886652,
     "wof:name":"Ambuila",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/971/3/1108799713.geojson
+++ b/data/110/879/971/3/1108799713.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.172498,
-    "geom:area_square_m":2104825145.681204,
+    "geom:area_square_m":2104825309.264071,
     "geom:bbox":"14.388068,-9.488526,15.188968,-9.099675",
     "geom:latitude":-9.318512,
     "geom:longitude":14.780124,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.CN.CZ",
         "wd:id":"Q1619683"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985289,
-    "wof:geomhash":"b3111b5b35074ecad7a6a7edc2c8a013",
+    "wof:geomhash":"7d0a63e5197c2910cdca1102a6d89178",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799713,
-    "wof:lastmodified":1690850257,
+    "wof:lastmodified":1695886652,
     "wof:name":"Kazengo",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/971/5/1108799715.geojson
+++ b/data/110/879/971/5/1108799715.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.234077,
-    "geom:area_square_m":2874813199.079039,
+    "geom:area_square_m":2874812828.6525,
     "geom:bbox":"15.576738,-7.021874,16.028466,-6.237466",
     "geom:latitude":-6.668364,
     "geom:longitude":15.827438,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.UI.BU",
         "wd:id":"Q529876"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985290,
-    "wof:geomhash":"7e10362c242cbb00a106ff3d84015b28",
+    "wof:geomhash":"8c1b442d9b372b0eee00d9c381902774",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799715,
-    "wof:lastmodified":1690850257,
+    "wof:lastmodified":1695886653,
     "wof:name":"Buengas",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/971/7/1108799717.geojson
+++ b/data/110/879/971/7/1108799717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.501475,
-    "geom:area_square_m":6027080525.788527,
+    "geom:area_square_m":6027080531.999103,
     "geom:bbox":"13.289779,-13.873994,14.487196,-13.118063",
     "geom:latitude":-13.594711,
     "geom:longitude":13.805051,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.BG.CH",
         "wd:id":"Q524469"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985291,
-    "wof:geomhash":"5a1470e331276e27dfbdbd0607226925",
+    "wof:geomhash":"60187524685abd589d627e8ea2e569c2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799717,
-    "wof:lastmodified":1690850256,
+    "wof:lastmodified":1695886652,
     "wof:name":"Chongoroi",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/971/9/1108799719.geojson
+++ b/data/110/879/971/9/1108799719.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.893747,
-    "geom:area_square_m":10855728857.358803,
+    "geom:area_square_m":10855729999.434217,
     "geom:bbox":"16.446292,-11.73238,18.202358,-10.239492",
     "geom:latitude":-10.790669,
     "geom:longitude":17.38924,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.ML.LU",
         "wd:id":"Q577901"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985293,
-    "wof:geomhash":"08c537c4b879c59c7e4783ce73955b51",
+    "wof:geomhash":"c122cd14eaee28fec67e563d641b4923",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799719,
-    "wof:lastmodified":1690850256,
+    "wof:lastmodified":1695886652,
     "wof:name":"Lukembo",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/972/3/1108799723.geojson
+++ b/data/110/879/972/3/1108799723.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.419628,
-    "geom:area_square_m":5031586237.243125,
+    "geom:area_square_m":5031586633.709346,
     "geom:bbox":"13.574372,-14.521513,14.374235,-13.799224",
     "geom:latitude":-14.138067,
     "geom:longitude":13.955178,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.HL.QL",
         "wd:id":"Q598594"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985294,
-    "wof:geomhash":"a26028720dcbc8d3b3601e0e22b17bd6",
+    "wof:geomhash":"b9143c97901ab87bd35fa561e15096e6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799723,
-    "wof:lastmodified":1690850277,
+    "wof:lastmodified":1695886660,
     "wof:name":"Kilengue",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/972/5/1108799725.geojson
+++ b/data/110/879/972/5/1108799725.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.272282,
-    "geom:area_square_m":3328426465.250554,
+    "geom:area_square_m":3328426814.476997,
     "geom:bbox":"16.992107,-8.990343,17.608439,-8.262155",
     "geom:latitude":-8.659516,
     "geom:longitude":17.358232,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.ML.CD",
         "wd:id":"Q1621589"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985295,
-    "wof:geomhash":"66d39bf00e3e0bfba3370cff105f2220",
+    "wof:geomhash":"31d68d9d7ad759a719aff6ca7ae1bafc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799725,
-    "wof:lastmodified":1690850277,
+    "wof:lastmodified":1695886660,
     "wof:name":"Kunda-ia-Baze",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/972/7/1108799727.geojson
+++ b/data/110/879/972/7/1108799727.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.35787,
-    "geom:area_square_m":4308886640.552786,
+    "geom:area_square_m":4308886956.240014,
     "geom:bbox":"13.962416,-13.624526,14.647396,-12.681825",
     "geom:latitude":-13.159683,
     "geom:longitude":14.349918,
@@ -160,9 +160,10 @@
         "hasc:id":"AO.BG.CU",
         "wd:id":"Q1142891"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985298,
-    "wof:geomhash":"8d5b12d5071bf2cc8be52f166b2fe951",
+    "wof:geomhash":"a6d71f7293a4443e62fcec90b3a267bd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -172,7 +173,7 @@
         }
     ],
     "wof:id":1108799727,
-    "wof:lastmodified":1690850277,
+    "wof:lastmodified":1695886068,
     "wof:name":"Cubal",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/972/9/1108799729.geojson
+++ b/data/110/879/972/9/1108799729.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.248463,
-    "geom:area_square_m":39240778095.820168,
+    "geom:area_square_m":39240778751.890335,
     "geom:bbox":"18.331853,-13.291737,21.310605,-11.249112",
     "geom:latitude":-12.326612,
     "geom:longitude":19.782492,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"AO.MX.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985299,
-    "wof:geomhash":"31d92c10b318860eb3b782ea742759e0",
+    "wof:geomhash":"0907b15250533b3f434bb52343c4b4be",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108799729,
-    "wof:lastmodified":1636502538,
+    "wof:lastmodified":1695886068,
     "wof:name":"Moxico",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/973/1/1108799731.geojson
+++ b/data/110/879/973/1/1108799731.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.71584,
-    "geom:area_square_m":8779132900.206367,
+    "geom:area_square_m":8779133757.657104,
     "geom:bbox":"12.833717,-7.800718,13.969803,-6.890243",
     "geom:latitude":-7.328385,
     "geom:longitude":13.395428,
@@ -166,9 +166,10 @@
         "hasc:id":"AO.ZA.NZ",
         "wd:id":"Q2351452"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985302,
-    "wof:geomhash":"acd81e0c2ca727364b545d36f3734b7f",
+    "wof:geomhash":"126902a78c54efa5ea84cfd188078a07",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -178,7 +179,7 @@
         }
     ],
     "wof:id":1108799731,
-    "wof:lastmodified":1690850270,
+    "wof:lastmodified":1695886067,
     "wof:name":"Nzeto",
     "wof:parent_id":85667677,
     "wof:placetype":"county",

--- a/data/110/879/973/3/1108799733.geojson
+++ b/data/110/879/973/3/1108799733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.081442,
-    "geom:area_square_m":995401163.681641,
+    "geom:area_square_m":995401480.199569,
     "geom:bbox":"15.035214,-8.968076,15.347263,-8.481495",
     "geom:latitude":-8.720426,
     "geom:longitude":15.203681,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.CN.BN",
         "wd:id":"Q2227542"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985303,
-    "wof:geomhash":"19bc1dc4cf6d83be1b643207c71567c0",
+    "wof:geomhash":"e01df53bb3021e299c0b1922f96cdb37",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799733,
-    "wof:lastmodified":1690850271,
+    "wof:lastmodified":1695886658,
     "wof:name":"Banga",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/973/5/1108799735.geojson
+++ b/data/110/879/973/5/1108799735.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.256037,
-    "geom:area_square_m":3090138388.894309,
+    "geom:area_square_m":3090137953.104094,
     "geom:bbox":"16.30442,-12.981746,16.861086,-12.107568",
     "geom:latitude":-12.561997,
     "geom:longitude":16.574963,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.BI.CG",
         "wd:id":"Q2342456"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985304,
-    "wof:geomhash":"df864e3ec05b7cbfce039dee81764186",
+    "wof:geomhash":"9b08ddd186d1343e3a630da07a3ec869",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799735,
-    "wof:lastmodified":1690850271,
+    "wof:lastmodified":1695886658,
     "wof:name":"Chinguar",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/973/7/1108799737.geojson
+++ b/data/110/879/973/7/1108799737.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.222575,
-    "geom:area_square_m":2688389441.120753,
+    "geom:area_square_m":2688389155.140744,
     "geom:bbox":"14.45424,-12.620557,15.078073,-12.07731",
     "geom:latitude":-12.360353,
     "geom:longitude":14.784984,
@@ -127,9 +127,10 @@
         "hasc:id":"AO.BG.BA",
         "wd:id":"Q805495"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985306,
-    "wof:geomhash":"87d56015de06da1784daf1b03425a8ab",
+    "wof:geomhash":"e516014a1bb6f627753cf1181b095798",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108799737,
-    "wof:lastmodified":1690850270,
+    "wof:lastmodified":1695886658,
     "wof:name":"Balombo",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/974/1/1108799741.geojson
+++ b/data/110/879/974/1/1108799741.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.564543,
-    "geom:area_square_m":18447597145.04781,
+    "geom:area_square_m":18447597102.73695,
     "geom:bbox":"19.707183,-18.039104,21.764159,-16.993151",
     "geom:latitude":-17.526637,
     "geom:longitude":20.831388,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.CC.DI",
         "wd:id":"Q1619260"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985308,
-    "wof:geomhash":"e721a88dcbaef027435dbb76917c5079",
+    "wof:geomhash":"66ab187d427e47e5c90a0cba61bd1f78",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799741,
-    "wof:lastmodified":1690850272,
+    "wof:lastmodified":1695886658,
     "wof:name":"Dirico",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/974/3/1108799743.geojson
+++ b/data/110/879/974/3/1108799743.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.47476,
-    "geom:area_square_m":5780183982.089412,
+    "geom:area_square_m":5780183461.75569,
     "geom:bbox":"14.539428,-10.479869,15.466982,-9.676496",
     "geom:latitude":-10.061637,
     "geom:longitude":14.990133,
@@ -91,9 +91,10 @@
         "hasc:id":"AO.CS.LI",
         "wd:id":"Q2342256"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985309,
-    "wof:geomhash":"1beb2e263340f0d381a4b9a2f0b30538",
+    "wof:geomhash":"74afb74f99c72d9e576310ae82aa7b6b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108799743,
-    "wof:lastmodified":1690850272,
+    "wof:lastmodified":1695886658,
     "wof:name":"Libolo",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/974/5/1108799745.geojson
+++ b/data/110/879/974/5/1108799745.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002359,
-    "geom:area_square_m":28816205.78051,
+    "geom:area_square_m":28816145.397406,
     "geom:bbox":"13.179128,-8.891587,13.260272,-8.821335",
     "geom:latitude":-8.853776,
     "geom:longitude":13.221721,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"AO.LU.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985310,
-    "wof:geomhash":"8fe364464da3ee837f42478232fca219",
+    "wof:geomhash":"eb66a47ded49ffb4c7058c46c40becfb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108799745,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Maianga",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/974/7/1108799747.geojson
+++ b/data/110/879/974/7/1108799747.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.295347,
-    "geom:area_square_m":3570068381.329101,
+    "geom:area_square_m":3570068393.248862,
     "geom:bbox":"13.477124,-12.608418,14.245273,-11.761812",
     "geom:latitude":-12.159475,
     "geom:longitude":13.848774,
@@ -79,9 +79,10 @@
         "hasc:id":"AO.BG.LO",
         "wd:id":"Q3835944"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985312,
-    "wof:geomhash":"a794d7c2840b9cadadaf20cf5a943277",
+    "wof:geomhash":"2d7b821bc69ddcb2f87cafa3c858e0a3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -91,7 +92,7 @@
         }
     ],
     "wof:id":1108799747,
-    "wof:lastmodified":1690850271,
+    "wof:lastmodified":1695886067,
     "wof:name":"Lobito",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/974/9/1108799749.geojson
+++ b/data/110/879/974/9/1108799749.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.093732,
-    "geom:area_square_m":1119124272.080222,
+    "geom:area_square_m":1119124153.704092,
     "geom:bbox":"13.214118,-15.348495,13.534341,-14.851056",
     "geom:latitude":-15.075791,
     "geom:longitude":13.375942,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.HL.HU",
         "wd:id":"Q1010646"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985313,
-    "wof:geomhash":"ab452b3e8d69002223efeebe86bc2585",
+    "wof:geomhash":"13d25e97a0863d31cb33e72b12c86eb3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799749,
-    "wof:lastmodified":1690850271,
+    "wof:lastmodified":1695886658,
     "wof:name":"Humpata",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/975/1/1108799751.geojson
+++ b/data/110/879/975/1/1108799751.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.3946,
-    "geom:area_square_m":4849991208.075558,
+    "geom:area_square_m":4849990961.149923,
     "geom:bbox":"12.272861,-6.731924,13.15217,-5.863608",
     "geom:latitude":-6.280469,
     "geom:longitude":12.733611,
@@ -175,9 +175,10 @@
         "hasc:id":"AO.ZA.SO",
         "wd:id":"Q1015108"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985315,
-    "wof:geomhash":"236f032d4ca067eff08895f8a14d26fd",
+    "wof:geomhash":"d558a76eb71244b4de43e34025274962",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -187,7 +188,7 @@
         }
     ],
     "wof:id":1108799751,
-    "wof:lastmodified":1690850276,
+    "wof:lastmodified":1695886067,
     "wof:name":"Soyo",
     "wof:parent_id":85667677,
     "wof:placetype":"county",

--- a/data/110/879/975/3/1108799753.geojson
+++ b/data/110/879/975/3/1108799753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.10876,
-    "geom:area_square_m":1334517359.6359,
+    "geom:area_square_m":1334517467.083908,
     "geom:bbox":"14.720633,-7.380183,15.277222,-6.768783",
     "geom:latitude":-7.103601,
     "geom:longitude":15.046834,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.UI.MU",
         "wd:id":"Q1621358"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985316,
-    "wof:geomhash":"27d609feaed853c05befd5399c6ad10e",
+    "wof:geomhash":"6d4f4df9538b89abc5a01c403d9c77f3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799753,
-    "wof:lastmodified":1690850276,
+    "wof:lastmodified":1695886660,
     "wof:name":"Mucaba",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/975/5/1108799755.geojson
+++ b/data/110/879/975/5/1108799755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.173191,
-    "geom:area_square_m":2112292459.542695,
+    "geom:area_square_m":2112292660.625105,
     "geom:bbox":"16.624334,-9.667034,17.297327,-9.21872",
     "geom:latitude":-9.480373,
     "geom:longitude":16.922517,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.ML.MU",
         "wd:id":"Q1621535"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985317,
-    "wof:geomhash":"dd09f109e03bf30be29e506a95b744bb",
+    "wof:geomhash":"4dac6e87d051a89568aebf1c782c7a24",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799755,
-    "wof:lastmodified":1690850277,
+    "wof:lastmodified":1695886660,
     "wof:name":"Mukari",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/975/9/1108799759.geojson
+++ b/data/110/879/975/9/1108799759.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.182691,
-    "geom:area_square_m":14434269371.327507,
+    "geom:area_square_m":14434269445.662647,
     "geom:bbox":"18.408033,-10.009307,20.04484,-8.656408",
     "geom:latitude":-9.239246,
     "geom:longitude":19.320922,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.LN.LU",
         "wd:id":"Q2351441"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985318,
-    "wof:geomhash":"e9de26becb5d9b14ad8f990ab324f2e0",
+    "wof:geomhash":"ca55b65fb33fa849df65982ac5d5f41c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799759,
-    "wof:lastmodified":1690850276,
+    "wof:lastmodified":1695886659,
     "wof:name":"Lubalo",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/110/879/976/1/1108799761.geojson
+++ b/data/110/879/976/1/1108799761.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.535762,
-    "geom:area_square_m":18201437777.763596,
+    "geom:area_square_m":18201437377.882851,
     "geom:bbox":"11.674556,-17.273807,13.354115,-15.521432",
     "geom:latitude":-16.56435,
     "geom:longitude":12.363065,
@@ -73,9 +73,10 @@
         "hasc:id":"AO.NA.TO",
         "wd:id":"Q4001307"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985319,
-    "wof:geomhash":"97f712de3508845d381ac6717e665ff5",
+    "wof:geomhash":"a49fb7bcb20c904c37d627d735b7f4a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108799761,
-    "wof:lastmodified":1690850259,
+    "wof:lastmodified":1695886653,
     "wof:name":"Tombua",
     "wof:parent_id":85667717,
     "wof:placetype":"county",

--- a/data/110/879/976/3/1108799763.geojson
+++ b/data/110/879/976/3/1108799763.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.536742,
-    "geom:area_square_m":6596292372.669055,
+    "geom:area_square_m":6596292229.753935,
     "geom:bbox":"15.957684,-6.750028,16.767978,-5.843677",
     "geom:latitude":-6.33879,
     "geom:longitude":16.35989,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.UI.QM",
         "wd:id":"Q1621596"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985321,
-    "wof:geomhash":"b9aef85e09a5e04b60856d68ae2df412",
+    "wof:geomhash":"6a4428376602e6d002714aa4b0d37453",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799763,
-    "wof:lastmodified":1690850260,
+    "wof:lastmodified":1695886654,
     "wof:name":"Kimbele",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/976/5/1108799765.geojson
+++ b/data/110/879/976/5/1108799765.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.164706,
-    "geom:area_square_m":2017653209.522975,
+    "geom:area_square_m":2017653337.834276,
     "geom:bbox":"15.053561,-8.056504,15.722571,-7.588634",
     "geom:latitude":-7.825493,
     "geom:longitude":15.390422,
@@ -130,9 +130,10 @@
         "hasc:id":"AO.UI.NE",
         "wd:id":"Q748830"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985322,
-    "wof:geomhash":"9d39085dac6c42189eeaf67b1a7ea74b",
+    "wof:geomhash":"d8e614b441b119940fad326314b10b29",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108799765,
-    "wof:lastmodified":1690850260,
+    "wof:lastmodified":1695886654,
     "wof:name":"Negage",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/976/7/1108799767.geojson
+++ b/data/110/879/976/7/1108799767.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.748059,
-    "geom:area_square_m":20726694429.422817,
+    "geom:area_square_m":20726694433.727272,
     "geom:bbox":"15.179605,-17.304254,17.429571,-15.749592",
     "geom:latitude":-16.480193,
     "geom:longitude":16.326329,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.CU.CN",
         "wd:id":"Q3817632"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985323,
-    "wof:geomhash":"0e45a81c9ca507c182c8ad284969f51e",
+    "wof:geomhash":"fbfbbd52cbacded61b2313769e8e6a22",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799767,
-    "wof:lastmodified":1690850259,
+    "wof:lastmodified":1695886653,
     "wof:name":"Kwanyama",
     "wof:parent_id":85667701,
     "wof:placetype":"county",

--- a/data/110/879/976/9/1108799769.geojson
+++ b/data/110/879/976/9/1108799769.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.122295,
-    "geom:area_square_m":1506335194.79,
+    "geom:area_square_m":1506335008.942149,
     "geom:bbox":"12.005028,-5.284769,12.480035,-4.793056",
     "geom:latitude":-5.046372,
     "geom:longitude":12.241363,
@@ -103,9 +103,10 @@
         "hasc:id":"AO.CB.CC",
         "wd:id":"Q1025053"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985324,
-    "wof:geomhash":"f50834f806592ca4cb240b7c0ded958a",
+    "wof:geomhash":"6b53d04630d66d970ed4a47c691b02b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108799769,
-    "wof:lastmodified":1690850259,
+    "wof:lastmodified":1695886654,
     "wof:name":"Landana",
     "wof:parent_id":85667683,
     "wof:placetype":"county",

--- a/data/110/879/977/1/1108799771.geojson
+++ b/data/110/879/977/1/1108799771.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.561313,
-    "geom:area_square_m":6832689344.430781,
+    "geom:area_square_m":6832688836.639469,
     "geom:bbox":"16.936985,-10.547171,18.083394,-9.581336",
     "geom:latitude":-10.12112,
     "geom:longitude":17.450534,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.ML.CC",
         "wd:id":"Q1621393"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985325,
-    "wof:geomhash":"b4c6b8b927c704775b6b04e838eb8fca",
+    "wof:geomhash":"991206545ed44559f063ee490e1b9bd4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799771,
-    "wof:lastmodified":1690850250,
+    "wof:lastmodified":1695886650,
     "wof:name":"Kambundi-Katembo",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/977/3/1108799773.geojson
+++ b/data/110/879/977/3/1108799773.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.120474,
-    "geom:area_square_m":1454185996.71344,
+    "geom:area_square_m":1454186153.104187,
     "geom:bbox":"15.275042,-12.765688,15.700178,-12.284403",
     "geom:latitude":-12.531942,
     "geom:longitude":15.49207,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.HM.EK",
         "wd:id":"Q1619933"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985326,
-    "wof:geomhash":"a17a14f2ff95f433539a2c287eaf3d7b",
+    "wof:geomhash":"22d9e95774b4fde689aa2fec37cf327c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799773,
-    "wof:lastmodified":1690850251,
+    "wof:lastmodified":1695886650,
     "wof:name":"Ekunha",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/977/7/1108799777.geojson
+++ b/data/110/879/977/7/1108799777.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.199142,
-    "geom:area_square_m":2451244151.457283,
+    "geom:area_square_m":2451244070.216059,
     "geom:bbox":"12.145389,-5.774131,12.536667,-5.093487",
     "geom:latitude":-5.461229,
     "geom:longitude":12.367804,
@@ -259,9 +259,10 @@
         "hasc:id":"AO.CB.CB",
         "wd:id":"Q459360"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985328,
-    "wof:geomhash":"8424baff40a17313435b124b4e99fa58",
+    "wof:geomhash":"8dfa91b78bf95d71d0e31f157f33997d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -271,7 +272,7 @@
         }
     ],
     "wof:id":1108799777,
-    "wof:lastmodified":1690850250,
+    "wof:lastmodified":1695886064,
     "wof:name":"Cabinda",
     "wof:parent_id":85667683,
     "wof:placetype":"county",

--- a/data/110/879/977/9/1108799779.geojson
+++ b/data/110/879/977/9/1108799779.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.51137,
-    "geom:area_square_m":29716720038.126019,
+    "geom:area_square_m":29716718901.537434,
     "geom:bbox":"20.70156,-17.962158,23.434232,-15.578913",
     "geom:latitude":-16.861125,
     "geom:longitude":21.964952,
@@ -91,9 +91,10 @@
         "hasc:id":"AO.CC.RI",
         "wd:id":"Q1619904"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985329,
-    "wof:geomhash":"102b8c2d2f7241e9dec903d9e71b0fea",
+    "wof:geomhash":"3325d57d3fde3addd1a2088c348da030",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1108799779,
-    "wof:lastmodified":1690850250,
+    "wof:lastmodified":1695886650,
     "wof:name":"Rivungo",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/978/1/1108799781.geojson
+++ b/data/110/879/978/1/1108799781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.568956,
-    "geom:area_square_m":6850202402.901402,
+    "geom:area_square_m":6850202230.980328,
     "geom:bbox":"12.522056,-13.619302,13.647497,-12.592944",
     "geom:latitude":-13.168293,
     "geom:longitude":13.111447,
@@ -127,9 +127,10 @@
         "hasc:id":"AO.BG.BF",
         "wd:id":"Q812706"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985330,
-    "wof:geomhash":"a1be9723363245cc28926b55dfaa4476",
+    "wof:geomhash":"94205b4eb73b8030c55873a41710a43f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108799781,
-    "wof:lastmodified":1690850255,
+    "wof:lastmodified":1695886652,
     "wof:name":"Baia Farta",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/978/3/1108799783.geojson
+++ b/data/110/879/978/3/1108799783.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.83922,
-    "geom:area_square_m":9954028591.504938,
+    "geom:area_square_m":9954028545.550884,
     "geom:bbox":"13.623284,-16.990615,15.048967,-15.848528",
     "geom:latitude":-16.415033,
     "geom:longitude":14.253426,
@@ -124,9 +124,10 @@
         "hasc:id":"AO.CU.CA",
         "wd:id":"Q2350857"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985332,
-    "wof:geomhash":"229c54594157c8e89f214d9a1ba45377",
+    "wof:geomhash":"1e296f6779eccdf4c4638f174b10c890",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -136,7 +137,7 @@
         }
     ],
     "wof:id":1108799783,
-    "wof:lastmodified":1690850256,
+    "wof:lastmodified":1695886065,
     "wof:name":"Kahama",
     "wof:parent_id":85667701,
     "wof:placetype":"county",

--- a/data/110/879/978/5/1108799785.geojson
+++ b/data/110/879/978/5/1108799785.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026948,
-    "geom:area_square_m":329102974.784445,
+    "geom:area_square_m":329102974.784474,
     "geom:bbox":"12.993721962,-9.12142144805,13.2362944236,-8.811249733",
     "geom:latitude":-9.006958,
     "geom:longitude":13.12622,
@@ -258,9 +258,10 @@
     "wof:concordances":{
         "hasc:id":"AO.LU.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985334,
-    "wof:geomhash":"abba8c930561232ba9a198b8772960da",
+    "wof:geomhash":"0927570dd82e91085878f09abec09b31",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -270,7 +271,7 @@
         }
     ],
     "wof:id":1108799785,
-    "wof:lastmodified":1566586698,
+    "wof:lastmodified":1695886652,
     "wof:name":"Samba",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/978/7/1108799787.geojson
+++ b/data/110/879/978/7/1108799787.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.249295,
-    "geom:area_square_m":27375967680.992992,
+    "geom:area_square_m":27375966895.270737,
     "geom:bbox":"20.599165,-11.312244,22.315,-9.03742",
     "geom:latitude":-10.157295,
     "geom:longitude":21.423477,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.LS.MU",
         "wd:id":"Q1620876"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985335,
-    "wof:geomhash":"b0d93812d678cae1d204e072e9018d9d",
+    "wof:geomhash":"3d598b1a44414b06a17c088d59881d30",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799787,
-    "wof:lastmodified":1690850255,
+    "wof:lastmodified":1695886652,
     "wof:name":"Mukonda",
     "wof:parent_id":85667651,
     "wof:placetype":"county",

--- a/data/110/879/978/9/1108799789.geojson
+++ b/data/110/879/978/9/1108799789.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.33769,
-    "geom:area_square_m":4117926688.410088,
+    "geom:area_square_m":4117927050.261139,
     "geom:bbox":"14.093987,-9.782211,15.17053,-9.163895",
     "geom:latitude":-9.533527,
     "geom:longitude":14.590958,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.CN.CN",
         "wd:id":"Q1003771"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985337,
-    "wof:geomhash":"0c003da9c938a06fbbfb5adbf7e1b6a0",
+    "wof:geomhash":"3d18d6957916329cf598fae32b0571c7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799789,
-    "wof:lastmodified":1690850255,
+    "wof:lastmodified":1695886652,
     "wof:name":"Kambambe",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/979/1/1108799791.geojson
+++ b/data/110/879/979/1/1108799791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.639933,
-    "geom:area_square_m":7744530317.862426,
+    "geom:area_square_m":7744530478.389367,
     "geom:bbox":"20.685309,-12.313318,21.775869,-11.240078",
     "geom:latitude":-11.837695,
     "geom:longitude":21.270348,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.MX.CA",
         "wd:id":"Q3840597"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985339,
-    "wof:geomhash":"ffd1cecbff40488e5e4f4d0feca3dd2d",
+    "wof:geomhash":"8d7d024bfcfa20715025a1b035cdb3d9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799791,
-    "wof:lastmodified":1690850254,
+    "wof:lastmodified":1695886652,
     "wof:name":"Kameia",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/979/5/1108799795.geojson
+++ b/data/110/879/979/5/1108799795.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.337269,
-    "geom:area_square_m":4086667869.281509,
+    "geom:area_square_m":4086667976.533088,
     "geom:bbox":"13.767083,-11.99996,14.537733,-10.866658",
     "geom:latitude":-11.497182,
     "geom:longitude":14.047552,
@@ -76,9 +76,10 @@
         "hasc:id":"AO.CS.SU",
         "wd:id":"Q3976898"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985340,
-    "wof:geomhash":"52de42fd2b9483c96455cf7f73046ce7",
+    "wof:geomhash":"9b53564269f5ab3bf2fed1b247c8d6f5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108799795,
-    "wof:lastmodified":1636502535,
+    "wof:lastmodified":1695886066,
     "wof:name":"Sumbe",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/979/7/1108799797.geojson
+++ b/data/110/879/979/7/1108799797.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.530162,
-    "geom:area_square_m":6481754252.600055,
+    "geom:area_square_m":6481754327.897109,
     "geom:bbox":"17.533506,-9.249367,18.563692,-8.076907",
     "geom:latitude":-8.599897,
     "geom:longitude":18.067916,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.LN.CN",
         "wd:id":"Q1620710"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985342,
-    "wof:geomhash":"50cb711b24539e34e22f1ee69e578e1e",
+    "wof:geomhash":"b14bd7541f8ff4e5306a323a1ef78cf3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799797,
-    "wof:lastmodified":1690850254,
+    "wof:lastmodified":1695886651,
     "wof:name":"Kuango",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/110/879/979/9/1108799799.geojson
+++ b/data/110/879/979/9/1108799799.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.330642,
-    "geom:area_square_m":4007000914.753705,
+    "geom:area_square_m":4007001198.127671,
     "geom:bbox":"14.024908,-11.720268,14.943653,-11.153088",
     "geom:latitude":-11.455515,
     "geom:longitude":14.499466,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.CS.SE",
         "wd:id":"Q2572141"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985343,
-    "wof:geomhash":"0e9e754d1c997f1dd150d07716b57bcd",
+    "wof:geomhash":"22a27b3ccd2ebdced3ba6fd7d44051c4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799799,
-    "wof:lastmodified":1690850254,
+    "wof:lastmodified":1695886652,
     "wof:name":"Seles",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/980/1/1108799801.geojson
+++ b/data/110/879/980/1/1108799801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.994572,
-    "geom:area_square_m":11889202669.800856,
+    "geom:area_square_m":11889202047.984468,
     "geom:bbox":"15.266546,-15.484559,16.389893,-14.068074",
     "geom:latitude":-14.811672,
     "geom:longitude":15.846056,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.HL.JA",
         "wd:id":"Q3806439"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985345,
-    "wof:geomhash":"58b1f1e0fb3d58921e52f266b684718b",
+    "wof:geomhash":"ffca5c44ce14e027086c3fc2c1c11162",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799801,
-    "wof:lastmodified":1690850273,
+    "wof:lastmodified":1695886658,
     "wof:name":"Jamba",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/980/3/1108799803.geojson
+++ b/data/110/879/980/3/1108799803.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.160014,
-    "geom:area_square_m":1971645850.995303,
+    "geom:area_square_m":1971645836.176994,
     "geom:bbox":"12.290542,-5.065396,12.825105,-4.556899",
     "geom:latitude":-4.803914,
     "geom:longitude":12.547005,
@@ -103,9 +103,10 @@
         "hasc:id":"AO.CB.BZ",
         "wd:id":"Q1000367"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985346,
-    "wof:geomhash":"8fdd674ec628615440718fa0b1805108",
+    "wof:geomhash":"779651950c733dbeba6ac900f296b92d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108799803,
-    "wof:lastmodified":1690850273,
+    "wof:lastmodified":1695886658,
     "wof:name":"Buco Zau",
     "wof:parent_id":85667683,
     "wof:placetype":"county",

--- a/data/110/879/980/5/1108799805.geojson
+++ b/data/110/879/980/5/1108799805.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.497032,
-    "geom:area_square_m":6053408167.726751,
+    "geom:area_square_m":6053408484.507006,
     "geom:bbox":"16.216672,-10.343377,17.197338,-9.576083",
     "geom:latitude":-9.950903,
     "geom:longitude":16.686475,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.ML.CG",
         "wd:id":"Q1621362"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985347,
-    "wof:geomhash":"000235d36dc0ff58500a00c85f836cc6",
+    "wof:geomhash":"2b0b3d8493007f591c61aa83aa2af1a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799805,
-    "wof:lastmodified":1690850273,
+    "wof:lastmodified":1695886658,
     "wof:name":"Kangandala",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/980/7/1108799807.geojson
+++ b/data/110/879/980/7/1108799807.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.331737,
-    "geom:area_square_m":3979052753.964306,
+    "geom:area_square_m":3979052234.169297,
     "geom:bbox":"14.24934,-14.558034,14.874091,-13.55265",
     "geom:latitude":-14.06062,
     "geom:longitude":14.553021,
@@ -121,9 +121,10 @@
         "hasc:id":"AO.HL.CQ",
         "wd:id":"Q931694"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985348,
-    "wof:geomhash":"a4077c29042cb6c3f12b058aec7db6bb",
+    "wof:geomhash":"84dcbfc01cef270cafb69e8e43b4025f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108799807,
-    "wof:lastmodified":1690850272,
+    "wof:lastmodified":1695886659,
     "wof:name":"Kalukembe",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/980/9/1108799809.geojson
+++ b/data/110/879/980/9/1108799809.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.018081,
-    "geom:area_square_m":221130790.272569,
+    "geom:area_square_m":221130754.168961,
     "geom:bbox":"15.234617,-8.593387,15.447936,-8.384262",
     "geom:latitude":-8.488274,
     "geom:longitude":15.321644,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.CN.QU",
         "wd:id":"Q1619445"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985349,
-    "wof:geomhash":"489b2e111c57b54d0f486b882a2c2140",
+    "wof:geomhash":"e4a77d07b44461a145dcb22431aa1f8b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799809,
-    "wof:lastmodified":1690850272,
+    "wof:lastmodified":1695886659,
     "wof:name":"Kiculungo",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/981/3/1108799813.geojson
+++ b/data/110/879/981/3/1108799813.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000486,
-    "geom:area_square_m":5932809.382521,
+    "geom:area_square_m":5932886.851472,
     "geom:bbox":"13.251424,-8.839797,13.276509,-8.807048",
     "geom:latitude":-8.824359,
     "geom:longitude":13.265887,
@@ -82,9 +82,10 @@
         "hasc:id":"AO.LU.RA",
         "wd:id":"Q1003727"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985350,
-    "wof:geomhash":"89af577dbd159e417c0514c8c3087bd1",
+    "wof:geomhash":"34ed4b2ac58d1ad9a2f4ea9ab1e49386",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -94,7 +95,7 @@
         }
     ],
     "wof:id":1108799813,
-    "wof:lastmodified":1690850275,
+    "wof:lastmodified":1695886660,
     "wof:name":"Rangel",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/981/5/1108799815.geojson
+++ b/data/110/879/981/5/1108799815.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.284916,
-    "geom:area_square_m":3431330946.692387,
+    "geom:area_square_m":3431330768.511433,
     "geom:bbox":"13.574855,-13.406036,14.215937,-12.746745",
     "geom:latitude":-13.101236,
     "geom:longitude":13.925297,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.BG.CA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985353,
-    "wof:geomhash":"f807cb485e0d5702a85676a5d0d0f9be",
+    "wof:geomhash":"2a117b44b5e8b3781581278a85f11140",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799815,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Kaimbambo",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/981/7/1108799817.geojson
+++ b/data/110/879/981/7/1108799817.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.109541,
-    "geom:area_square_m":1339143026.87991,
+    "geom:area_square_m":1339143186.049682,
     "geom:bbox":"14.585154,-8.852086,14.996968,-8.349194",
     "geom:latitude":-8.632618,
     "geom:longitude":14.821546,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.BO.BA",
         "wd:id":"Q979174"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985354,
-    "wof:geomhash":"955ae358e1c10efbc662c28fcf5eacba",
+    "wof:geomhash":"91eb2f141f32f3b192fa1b5d529006c5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799817,
-    "wof:lastmodified":1690850275,
+    "wof:lastmodified":1695886659,
     "wof:name":"Bula Atumba",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/981/9/1108799819.geojson
+++ b/data/110/879/981/9/1108799819.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.291277,
-    "geom:area_square_m":3555852723.232206,
+    "geom:area_square_m":3555852411.225972,
     "geom:bbox":"13.468729,-9.538042,14.212386,-8.83686",
     "geom:latitude":-9.150616,
     "geom:longitude":13.863959,
@@ -121,9 +121,10 @@
         "hasc:id":"AO.BO.IB",
         "wd:id":"Q291729"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985355,
-    "wof:geomhash":"5d150673ba68c2ebf8fa76467f6a5b7c",
+    "wof:geomhash":"b654a590df6130bbafa18c1244b30768",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -133,7 +134,7 @@
         }
     ],
     "wof:id":1108799819,
-    "wof:lastmodified":1690850275,
+    "wof:lastmodified":1695886659,
     "wof:name":"Icolo e Bengo",
     "wof:parent_id":85667657,
     "wof:placetype":"county",

--- a/data/110/879/982/1/1108799821.geojson
+++ b/data/110/879/982/1/1108799821.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.614371,
-    "geom:area_square_m":19083837498.271812,
+    "geom:area_square_m":19083837117.341637,
     "geom:bbox":"17.223643,-17.837758,19.319454,-16.363391",
     "geom:latitude":-17.055028,
     "geom:longitude":18.1595,
@@ -151,9 +151,10 @@
         "hasc:id":"AO.CC.CN",
         "wd:id":"Q203050"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985357,
-    "wof:geomhash":"d0f6c5045e7253f0c3b3149df76987a5",
+    "wof:geomhash":"ed58b8b948cd7925d4589bffb0739def",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -163,7 +164,7 @@
         }
     ],
     "wof:id":1108799821,
-    "wof:lastmodified":1690850258,
+    "wof:lastmodified":1695886066,
     "wof:name":"Cuangar",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/982/3/1108799823.geojson
+++ b/data/110/879/982/3/1108799823.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.216871,
-    "geom:area_square_m":14774089323.603863,
+    "geom:area_square_m":14774090218.099802,
     "geom:bbox":"19.510993,-11.477896,21.21655,-10.347943",
     "geom:latitude":-10.922917,
     "geom:longitude":20.358709,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.LS.DA",
         "wd:id":"Q972373"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985359,
-    "wof:geomhash":"0bf38e6b607557dadcbff61093a9d748",
+    "wof:geomhash":"860d21880f905f295bc93b60c4218386",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799823,
-    "wof:lastmodified":1690850259,
+    "wof:lastmodified":1695886653,
     "wof:name":"Dala",
     "wof:parent_id":85667651,
     "wof:placetype":"county",

--- a/data/110/879/982/5/1108799825.geojson
+++ b/data/110/879/982/5/1108799825.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.213407,
-    "geom:area_square_m":2578893294.315256,
+    "geom:area_square_m":2578892927.681609,
     "geom:bbox":"15.020755,-12.518412,15.679133,-11.959594",
     "geom:latitude":-12.233422,
     "geom:longitude":15.292835,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.HM.LD",
         "wd:id":"Q1026734"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985360,
-    "wof:geomhash":"b0494f116e2dbe4ecd9b1564835a668b",
+    "wof:geomhash":"9ddd09314af7f9990ccfae415e86de5d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799825,
-    "wof:lastmodified":1690850259,
+    "wof:lastmodified":1695886654,
     "wof:name":"Londuimbali",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/982/7/1108799827.geojson
+++ b/data/110/879/982/7/1108799827.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09357,
-    "geom:area_square_m":1136182089.750431,
+    "geom:area_square_m":1136182325.453766,
     "geom:bbox":"14.167444,-11.081748,14.633715,-10.707519",
     "geom:latitude":-10.886512,
     "geom:longitude":14.407524,
@@ -85,9 +85,10 @@
         "hasc:id":"AO.CS.AM",
         "wd:id":"Q3613789"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985361,
-    "wof:geomhash":"f54c8978553db1edc69160f0a0c382c2",
+    "wof:geomhash":"232498929297e93870c1212c7c501d23",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108799827,
-    "wof:lastmodified":1690850258,
+    "wof:lastmodified":1695886653,
     "wof:name":"Amboim",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/983/1/1108799831.geojson
+++ b/data/110/879/983/1/1108799831.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.195505,
-    "geom:area_square_m":2354687786.175211,
+    "geom:area_square_m":2354687868.015612,
     "geom:bbox":"14.914786,-13.417809,15.456356,-12.670329",
     "geom:latitude":-13.083173,
     "geom:longitude":15.223234,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.HM.LG",
         "wd:id":"Q2342492"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985363,
-    "wof:geomhash":"77a1769a8bb7351efc518edebc7a4510",
+    "wof:geomhash":"ae2f69098bf4b60ec62c9bdfb28633b6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799831,
-    "wof:lastmodified":1690850251,
+    "wof:lastmodified":1695886650,
     "wof:name":"Longonjo",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/983/3/1108799833.geojson
+++ b/data/110/879/983/3/1108799833.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.933603,
-    "geom:area_square_m":11359161588.488758,
+    "geom:area_square_m":11359161296.86871,
     "geom:bbox":"15.263497,-11.00863,16.612919,-9.710938",
     "geom:latitude":-10.266984,
     "geom:longitude":15.980462,
@@ -118,9 +118,10 @@
         "hasc:id":"AO.CS.MU",
         "wd:id":"Q928298"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985364,
-    "wof:geomhash":"0fccf5eb4543923043b0e3bdbd906360",
+    "wof:geomhash":"52c2dd9653d7d2fb50cd113ef99a8a42",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108799833,
-    "wof:lastmodified":1690850251,
+    "wof:lastmodified":1695886650,
     "wof:name":"Mussende",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/983/5/1108799835.geojson
+++ b/data/110/879/983/5/1108799835.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.09133,
-    "geom:area_square_m":1125668487.160414,
+    "geom:area_square_m":1125668436.228632,
     "geom:bbox":"12.643977,-4.804752,13.102885,-4.387944",
     "geom:latitude":-4.60567,
     "geom:longitude":12.842163,
@@ -127,9 +127,10 @@
         "hasc:id":"AO.CB.BE",
         "wd:id":"Q815642"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985366,
-    "wof:geomhash":"b2aabf2271369679045d835ce928d74d",
+    "wof:geomhash":"58358e406b3abe942a9da64a84b4e3ff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -139,7 +140,7 @@
         }
     ],
     "wof:id":1108799835,
-    "wof:lastmodified":1690850252,
+    "wof:lastmodified":1695886066,
     "wof:name":"Belize",
     "wof:parent_id":85667683,
     "wof:placetype":"county",

--- a/data/110/879/983/7/1108799837.geojson
+++ b/data/110/879/983/7/1108799837.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.468643,
-    "geom:area_square_m":5661020764.223088,
+    "geom:area_square_m":5661020274.958605,
     "geom:bbox":"13.7979,-12.748588,14.739266,-11.826443",
     "geom:latitude":-12.335891,
     "geom:longitude":14.27224,
@@ -115,9 +115,10 @@
         "hasc:id":"AO.BG.BO",
         "wd:id":"Q287756"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985368,
-    "wof:geomhash":"17537fa0d5f38eb6ba0c1d20ec1fa979",
+    "wof:geomhash":"1853a9aa0e6ce64585d6374437189dc0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108799837,
-    "wof:lastmodified":1690850251,
+    "wof:lastmodified":1695886650,
     "wof:name":"Bocoio",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/983/9/1108799839.geojson
+++ b/data/110/879/983/9/1108799839.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.401607,
-    "geom:area_square_m":4823067636.495875,
+    "geom:area_square_m":4823067562.299747,
     "geom:bbox":"14.740285,-14.131518,15.54626,-13.38336",
     "geom:latitude":-13.776601,
     "geom:longitude":15.159943,
@@ -118,9 +118,10 @@
         "hasc:id":"AO.HL.CC",
         "wd:id":"Q2343957"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985369,
-    "wof:geomhash":"980a474b2423f50e1037b4ade20436bc",
+    "wof:geomhash":"8a746d09e02649d767bceeb71f6a7197",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -130,7 +131,7 @@
         }
     ],
     "wof:id":1108799839,
-    "wof:lastmodified":1690850251,
+    "wof:lastmodified":1695886650,
     "wof:name":"Kakonda",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/984/1/1108799841.geojson
+++ b/data/110/879/984/1/1108799841.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.399611,
-    "geom:area_square_m":4836464400.789289,
+    "geom:area_square_m":4836464438.404771,
     "geom:bbox":"14.461191,-12.205326,15.414319,-11.37562",
     "geom:latitude":-11.820984,
     "geom:longitude":14.969338,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.CS.CA",
         "wd:id":"Q591126"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985370,
-    "wof:geomhash":"aac90ab2dd31d6fe0dc9f845263216ef",
+    "wof:geomhash":"5845af102594218f688ead1b91c5d3a7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799841,
-    "wof:lastmodified":1690850252,
+    "wof:lastmodified":1695886651,
     "wof:name":"Kassongue",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/984/3/1108799843.geojson
+++ b/data/110/879/984/3/1108799843.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.281024,
-    "geom:area_square_m":3440603202.318389,
+    "geom:area_square_m":3440603474.644206,
     "geom:bbox":"14.637297,-8.410006,15.234001,-7.663991",
     "geom:latitude":-8.056957,
     "geom:longitude":14.91836,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.UI.QT",
         "wd:id":"Q1621604"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985371,
-    "wof:geomhash":"e06408c34409724a8492fd756380446d",
+    "wof:geomhash":"5746c278f1d7ad0b5e24e245789c984c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799843,
-    "wof:lastmodified":1690850252,
+    "wof:lastmodified":1695886651,
     "wof:name":"Kitexe",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/984/5/1108799845.geojson
+++ b/data/110/879/984/5/1108799845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.136806,
-    "geom:area_square_m":1649953330.574056,
+    "geom:area_square_m":1649953963.9501,
     "geom:bbox":"14.983178,-13.112817,15.371695,-12.40618",
     "geom:latitude":-12.743332,
     "geom:longitude":15.151102,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.HM.UC",
         "wd:id":"Q2351378"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985372,
-    "wof:geomhash":"7d2bfe1fa14a4070d07d57abaec35801",
+    "wof:geomhash":"0a6b26ffe97d0a669f2d3e6b637591c8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799845,
-    "wof:lastmodified":1690850253,
+    "wof:lastmodified":1695886651,
     "wof:name":"Ukuma",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/984/9/1108799849.geojson
+++ b/data/110/879/984/9/1108799849.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.667521,
-    "geom:area_square_m":7896118222.792834,
+    "geom:area_square_m":7896117403.012492,
     "geom:bbox":"13.144903,-17.438843,14.591624,-16.246013",
     "geom:latitude":-16.932257,
     "geom:longitude":13.793672,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.CU.CR",
         "wd:id":"Q1619967"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985373,
-    "wof:geomhash":"5f59d13058da2011dc9b70c0daef9876",
+    "wof:geomhash":"f0d46fcc990ed8c945ca67d97b174b93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799849,
-    "wof:lastmodified":1690850252,
+    "wof:lastmodified":1695886651,
     "wof:name":"Kuroka",
     "wof:parent_id":85667701,
     "wof:placetype":"county",

--- a/data/110/879/985/1/1108799851.geojson
+++ b/data/110/879/985/1/1108799851.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.855712,
-    "geom:area_square_m":10151145010.425379,
+    "geom:area_square_m":10151145353.049679,
     "geom:bbox":"18.01689,-16.960921,19.5759,-15.9301",
     "geom:latitude":-16.386742,
     "geom:longitude":18.738418,
@@ -65,7 +65,7 @@
     "wof:concordances":{},
     "wof:country":"AO",
     "wof:created":1483985374,
-    "wof:geomhash":"aef04efb7ba21ec7e28216a7a46bc380",
+    "wof:geomhash":"138e664287fb4d8218e50f08c47a1f24",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -75,7 +75,7 @@
         }
     ],
     "wof:id":1108799851,
-    "wof:lastmodified":1627521477,
+    "wof:lastmodified":1695887499,
     "wof:name":"Nancova",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/985/3/1108799853.geojson
+++ b/data/110/879/985/3/1108799853.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.232438,
-    "geom:area_square_m":2803155710.918571,
+    "geom:area_square_m":2803156063.568229,
     "geom:bbox":"15.949531,-13.369431,16.548853,-12.294853",
     "geom:latitude":-12.757103,
     "geom:longitude":16.321597,
@@ -110,9 +110,10 @@
         "hasc:id":"AO.HM.CT",
         "wd:id":"Q1619881"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985375,
-    "wof:geomhash":"7b7ad56ad709885130f1d497b68e222b",
+    "wof:geomhash":"022d5d1c648f92fa8a7fd6b1f891302e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -122,7 +123,7 @@
         }
     ],
     "wof:id":1108799853,
-    "wof:lastmodified":1690850258,
+    "wof:lastmodified":1695886653,
     "wof:name":"Kachiungo",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/985/5/1108799855.geojson
+++ b/data/110/879/985/5/1108799855.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.93391,
-    "geom:area_square_m":11451944844.776226,
+    "geom:area_square_m":11451945190.823284,
     "geom:bbox":"19.540188,-7.88276,21.227253,-6.913889",
     "geom:latitude":-7.391172,
     "geom:longitude":20.414899,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.LN.CH",
         "wd:id":"Q1620718"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985378,
-    "wof:geomhash":"2254742a9cb26b7768ddb157dfe1c801",
+    "wof:geomhash":"0a8f63e48d32d21d62c50258b90238b2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799855,
-    "wof:lastmodified":1690850258,
+    "wof:lastmodified":1695886653,
     "wof:name":"Chitato",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/110/879/985/7/1108799857.geojson
+++ b/data/110/879/985/7/1108799857.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.399116,
-    "geom:area_square_m":4839722773.942629,
+    "geom:area_square_m":4839723117.519959,
     "geom:bbox":"14.85099,-11.65618,15.799248,-10.953783",
     "geom:latitude":-11.284471,
     "geom:longitude":15.328013,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.CS.WK",
         "wd:id":"Q695397"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985379,
-    "wof:geomhash":"f151f516bd3c0507fc20c315332dac16",
+    "wof:geomhash":"c6a77cf65b297095e12d2baeca7b2704",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799857,
-    "wof:lastmodified":1690850257,
+    "wof:lastmodified":1695886653,
     "wof:name":"Waco Kungo",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/985/9/1108799859.geojson
+++ b/data/110/879/985/9/1108799859.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.113446,
-    "geom:area_square_m":1387353903.527538,
+    "geom:area_square_m":1387353679.20822,
     "geom:bbox":"14.266646,-8.727902,14.831231,-8.358281",
     "geom:latitude":-8.504666,
     "geom:longitude":14.552585,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.CN.DE",
         "wd:id":"Q1617496"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985380,
-    "wof:geomhash":"8808251f3e899f6d97e2517ec3bf9558",
+    "wof:geomhash":"db79aad777c8ab16cf02d8b61fb6609c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799859,
-    "wof:lastmodified":1690850257,
+    "wof:lastmodified":1695886653,
     "wof:name":"Dembos",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/986/1/1108799861.geojson
+++ b/data/110/879/986/1/1108799861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.864745,
-    "geom:area_square_m":46705256276.775269,
+    "geom:area_square_m":46705256932.920967,
     "geom:bbox":"21.234097,-13.417832,24.084445,-10.890127",
     "geom:latitude":-12.207523,
     "geom:longitude":22.907162,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.MX.AZ",
         "wd:id":"Q2343269"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985381,
-    "wof:geomhash":"15ca1e6d0144569e61abc8b42b85872c",
+    "wof:geomhash":"67d346878120c2b59c9333f06b1463c8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799861,
-    "wof:lastmodified":1690850278,
+    "wof:lastmodified":1695886660,
     "wof:name":"Alto Zambeze",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/986/3/1108799863.geojson
+++ b/data/110/879/986/3/1108799863.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149587,
-    "geom:area_square_m":1814619720.151047,
+    "geom:area_square_m":1814619357.704421,
     "geom:bbox":"14.135479,-11.353589,14.838959,-10.968835",
     "geom:latitude":-11.171569,
     "geom:longitude":14.4541,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.CS.CO",
         "wd:id":"Q1619974"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985382,
-    "wof:geomhash":"b85f60bbc9624984217302758e390b44",
+    "wof:geomhash":"8a49123f2ab77bd17b19f605e707294b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799863,
-    "wof:lastmodified":1690850279,
+    "wof:lastmodified":1695886660,
     "wof:name":"Konda",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/986/7/1108799867.geojson
+++ b/data/110/879/986/7/1108799867.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.351739,
-    "geom:area_square_m":4238497389.275383,
+    "geom:area_square_m":4238497069.140285,
     "geom:bbox":"15.785057,-13.449806,16.424009,-12.27846",
     "geom:latitude":-12.958535,
     "geom:longitude":16.095228,
@@ -98,9 +98,10 @@
         "hasc:id":"AO.HM.TT",
         "wd:id":"Q1619894"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985383,
-    "wof:geomhash":"f8093a40b215f3dd34de88b8f761d72a",
+    "wof:geomhash":"5246339b62dfa251d6128108e3f01a13",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -110,7 +111,7 @@
         }
     ],
     "wof:id":1108799867,
-    "wof:lastmodified":1690850278,
+    "wof:lastmodified":1695886660,
     "wof:name":"Thicala-Thilohanga",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/986/9/1108799869.geojson
+++ b/data/110/879/986/9/1108799869.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.319246,
-    "geom:area_square_m":3817791363.682294,
+    "geom:area_square_m":3817790687.325037,
     "geom:bbox":"13.370149,-15.130736,14.362305,-14.333016",
     "geom:latitude":-14.729245,
     "geom:longitude":13.833116,
@@ -73,9 +73,10 @@
         "hasc:id":"AO.HL.LU",
         "wd:id":"Q3837953"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985384,
-    "wof:geomhash":"23668a3903530081b1bbfc8b18e14043",
+    "wof:geomhash":"323ff2cbd93cdb8b36de9206309670dd",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -85,7 +86,7 @@
         }
     ],
     "wof:id":1108799869,
-    "wof:lastmodified":1690850278,
+    "wof:lastmodified":1695886660,
     "wof:name":"Lubango",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/987/1/1108799871.geojson
+++ b/data/110/879/987/1/1108799871.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.193146,
-    "geom:area_square_m":2355652103.415939,
+    "geom:area_square_m":2355651812.290963,
     "geom:bbox":"16.024909,-9.767913,16.65363,-9.135726",
     "geom:latitude":-9.481029,
     "geom:longitude":16.356905,
@@ -76,9 +76,10 @@
         "hasc:id":"AO.ML.ML",
         "wd:id":"Q3843776"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985391,
-    "wof:geomhash":"860099c8f0a5f4203ae861e65450444a",
+    "wof:geomhash":"2ff8d20a2c4c6694404b15ce09abe7e4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108799871,
-    "wof:lastmodified":1690850270,
+    "wof:lastmodified":1695886067,
     "wof:name":"Malanje",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/987/3/1108799873.geojson
+++ b/data/110/879/987/3/1108799873.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.600315,
-    "geom:area_square_m":7337591095.605012,
+    "geom:area_square_m":7337591260.558418,
     "geom:bbox":"15.618723,-9.351649,16.56109,-8.113921",
     "geom:latitude":-8.694385,
     "geom:longitude":16.008173,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.ML.CL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985393,
-    "wof:geomhash":"a9e1cca0138f45cc598b9f43ad88ff12",
+    "wof:geomhash":"0e1da109298e64ccf69d2932755548a9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799873,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695886720,
     "wof:name":"Kalandula",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/987/5/1108799875.geojson
+++ b/data/110/879/987/5/1108799875.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.588536,
-    "geom:area_square_m":7196876780.955568,
+    "geom:area_square_m":7196877319.778927,
     "geom:bbox":"13.344556,-8.943501,14.38536,-8.050026",
     "geom:latitude":-8.526343,
     "geom:longitude":13.853108,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"AO.BO.DA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985395,
-    "wof:geomhash":"e128f78a0d114f9fada1575656e32388",
+    "wof:geomhash":"70677525b01beb387b9e3869b8100268",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108799875,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Dande",
     "wof:parent_id":85667657,
     "wof:placetype":"county",

--- a/data/110/879/987/7/1108799877.geojson
+++ b/data/110/879/987/7/1108799877.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.992152,
-    "geom:area_square_m":11866821114.590902,
+    "geom:area_square_m":11866821061.099201,
     "geom:bbox":"16.471447,-15.504462,17.430926,-13.966711",
     "geom:latitude":-14.690909,
     "geom:longitude":16.967587,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.CC.CH",
         "wd:id":"Q2944829"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985397,
-    "wof:geomhash":"96266280e55c2303819ef29cd3ddd818",
+    "wof:geomhash":"7a75243730fc6004b967ec8d62ca6d60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799877,
-    "wof:lastmodified":1690850270,
+    "wof:lastmodified":1695886658,
     "wof:name":"Kuchi",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/987/9/1108799879.geojson
+++ b/data/110/879/987/9/1108799879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.151891,
-    "geom:area_square_m":14034101857.146891,
+    "geom:area_square_m":14034102004.780657,
     "geom:bbox":"13.152028,-10.438715,14.629698,-9.147004",
     "geom:latitude":-9.828813,
     "geom:longitude":13.850111,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.BO.MU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985400,
-    "wof:geomhash":"abd97085c882b58c7e9e7a0d7e8aeda4",
+    "wof:geomhash":"59bf6055b0b272864c4b194afb1b1909",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799879,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Kissama",
     "wof:parent_id":85667657,
     "wof:placetype":"county",

--- a/data/110/879/988/1/1108799881.geojson
+++ b/data/110/879/988/1/1108799881.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.117332,
-    "geom:area_square_m":1433360832.760125,
+    "geom:area_square_m":1433360972.434178,
     "geom:bbox":"14.548624,-9.057183,15.169245,-8.72292",
     "geom:latitude":-8.900961,
     "geom:longitude":14.902407,
@@ -94,9 +94,10 @@
         "hasc:id":"AO.CN.GO",
         "wd:id":"Q1619869"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985402,
-    "wof:geomhash":"3249c648e8fb35012adc7114ab29d673",
+    "wof:geomhash":"049100f6656aaba921a0b9394651534c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -106,7 +107,7 @@
         }
     ],
     "wof:id":1108799881,
-    "wof:lastmodified":1690850274,
+    "wof:lastmodified":1695886659,
     "wof:name":"Ngonguembo",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/988/5/1108799885.geojson
+++ b/data/110/879/988/5/1108799885.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.087089,
-    "geom:area_square_m":1050037873.520474,
+    "geom:area_square_m":1050037447.601434,
     "geom:bbox":"14.80356,-13.128518,15.058758,-12.541547",
     "geom:latitude":-12.816837,
     "geom:longitude":14.940263,
@@ -109,9 +109,10 @@
         "hasc:id":"AO.HM.TJ",
         "wd:id":"Q1619927"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985404,
-    "wof:geomhash":"91e302fa629326194a77e068b9d0cc5c",
+    "wof:geomhash":"58333b81477fb1cecceb1f9f50379c65",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -121,7 +122,7 @@
         }
     ],
     "wof:id":1108799885,
-    "wof:lastmodified":1690850275,
+    "wof:lastmodified":1695886659,
     "wof:name":"Chinjenje",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/988/7/1108799887.geojson
+++ b/data/110/879/988/7/1108799887.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.39361,
-    "geom:area_square_m":4802785426.914901,
+    "geom:area_square_m":4802785481.910303,
     "geom:bbox":"16.767917,-9.922073,17.814784,-8.892384",
     "geom:latitude":-9.317683,
     "geom:longitude":17.293413,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.ML.QL",
         "wd:id":"Q1621776"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985406,
-    "wof:geomhash":"27bf59c62953bf9a04e6ab27e9e75df9",
+    "wof:geomhash":"01a29c0815343c88ac80bbfe01dd2dd9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799887,
-    "wof:lastmodified":1690850274,
+    "wof:lastmodified":1695886659,
     "wof:name":"Kela",
     "wof:parent_id":85667653,
     "wof:placetype":"county",

--- a/data/110/879/988/9/1108799889.geojson
+++ b/data/110/879/988/9/1108799889.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.176203,
-    "geom:area_square_m":2160683980.471931,
+    "geom:area_square_m":2160683870.351365,
     "geom:bbox":"15.150621,-7.622221,15.764706,-7.143335",
     "geom:latitude":-7.390814,
     "geom:longitude":15.449168,
@@ -79,7 +79,7 @@
     },
     "wof:country":"AO",
     "wof:created":1483985408,
-    "wof:geomhash":"870c930317a290c82c36c30a19e0233e",
+    "wof:geomhash":"ba1de02f593e594f0bdc39fd3566f479",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -89,7 +89,7 @@
         }
     ],
     "wof:id":1108799889,
-    "wof:lastmodified":1690850274,
+    "wof:lastmodified":1695886659,
     "wof:name":"Bungo",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/989/1/1108799891.geojson
+++ b/data/110/879/989/1/1108799891.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.14125,
-    "geom:area_square_m":13819931153.154037,
+    "geom:area_square_m":13819930282.263906,
     "geom:bbox":"21.31015,-12.419769,22.716548,-11.091489",
     "geom:latitude":-11.668271,
     "geom:longitude":22.053674,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.MX.LN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985410,
-    "wof:geomhash":"e659ad04e0ab9500b713a17be917cefa",
+    "wof:geomhash":"6c7fa6fd420d3bd5175c94f737e2c278",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799891,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Luakano",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/989/3/1108799893.geojson
+++ b/data/110/879/989/3/1108799893.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.062532,
-    "geom:area_square_m":12579461844.727261,
+    "geom:area_square_m":12579462174.504539,
     "geom:bbox":"14.224381,-17.391865,15.591884,-16.001596",
     "geom:latitude":-16.768635,
     "geom:longitude":14.947335,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"AO.CU.OM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985411,
-    "wof:geomhash":"93feee0906391a9c82c22118de38414e",
+    "wof:geomhash":"0dddfccbe22e15510cc85a532dca73ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108799893,
-    "wof:lastmodified":1627521477,
+    "wof:lastmodified":1695886722,
     "wof:name":"Ombadja",
     "wof:parent_id":85667701,
     "wof:placetype":"county",

--- a/data/110/879/989/5/1108799895.geojson
+++ b/data/110/879/989/5/1108799895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.072144,
-    "geom:area_square_m":881089487.518578,
+    "geom:area_square_m":881089395.961488,
     "geom:bbox":"13.186901,-9.168919,13.533909,-8.842751",
     "geom:latitude":-9.000609,
     "geom:longitude":13.370688,
@@ -142,9 +142,10 @@
         "hasc:id":"AO.LU.VI",
         "wd:id":"Q2304294"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985412,
-    "wof:geomhash":"5a51a55fba805efcf98e7e02178f80fd",
+    "wof:geomhash":"9175f2029145d8d3b047746a329f65ef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -154,7 +155,7 @@
         }
     ],
     "wof:id":1108799895,
-    "wof:lastmodified":1690850274,
+    "wof:lastmodified":1695886068,
     "wof:name":"Viana",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/989/7/1108799897.geojson
+++ b/data/110/879/989/7/1108799897.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.307629,
-    "geom:area_square_m":15557042387.480572,
+    "geom:area_square_m":15557043204.938473,
     "geom:bbox":"12.203716,-16.464543,13.611611,-15.152677",
     "geom:latitude":-15.811799,
     "geom:longitude":12.945136,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.NA.VI",
         "wd:id":"Q2346656"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985413,
-    "wof:geomhash":"3025d33ca35937e8a30c962f5022a24c",
+    "wof:geomhash":"79f3e4b17e4880e4e34e446c6a3f197c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799897,
-    "wof:lastmodified":1690850274,
+    "wof:lastmodified":1695886659,
     "wof:name":"Virei",
     "wof:parent_id":85667717,
     "wof:placetype":"county",

--- a/data/110/879/989/9/1108799899.geojson
+++ b/data/110/879/989/9/1108799899.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.28833,
-    "geom:area_square_m":3544317086.696553,
+    "geom:area_square_m":3544317157.902312,
     "geom:bbox":"14.378844,-6.603282,14.985227,-5.874409",
     "geom:latitude":-6.210836,
     "geom:longitude":14.659896,
@@ -106,9 +106,10 @@
         "hasc:id":"AO.ZA.CU",
         "wd:id":"Q1620763"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985414,
-    "wof:geomhash":"8d2df27c7d580e98fa614e74808fb72a",
+    "wof:geomhash":"521da1d9d2e12059d2024b56f7fe0c99",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -118,7 +119,7 @@
         }
     ],
     "wof:id":1108799899,
-    "wof:lastmodified":1690850273,
+    "wof:lastmodified":1695886659,
     "wof:name":"Kuimba",
     "wof:parent_id":85667677,
     "wof:placetype":"county",

--- a/data/110/879/990/3/1108799903.geojson
+++ b/data/110/879/990/3/1108799903.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005432,
-    "geom:area_square_m":66359858.02082,
+    "geom:area_square_m":66359858.020826,
     "geom:bbox":"13.2015633401,-8.95515800213,13.3148410562,-8.83497884687",
     "geom:latitude":-8.885268,
     "geom:longitude":13.251104,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"AO.LU.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985415,
-    "wof:geomhash":"43d0aaa0d66f73365cbd3d79ceca025e",
+    "wof:geomhash":"627490de3b0c4aacf0ac7d13bfe2d629",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108799903,
-    "wof:lastmodified":1566586689,
+    "wof:lastmodified":1695886649,
     "wof:name":"Kilamba Kiaxi",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/990/5/1108799905.geojson
+++ b/data/110/879/990/5/1108799905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.11751,
-    "geom:area_square_m":1434597522.581324,
+    "geom:area_square_m":1434597522.581343,
     "geom:bbox":"15.0348808342,-9.37236982393,15.4837871824,-8.91059692348",
     "geom:latitude":-9.13753,
     "geom:longitude":15.239511,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.CN.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985416,
-    "wof:geomhash":"95866e06b75e5647a3d0a59f802b373f",
+    "wof:geomhash":"b6ea941207a6a8a6714866d8fe5b0021",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799905,
-    "wof:lastmodified":1566586690,
+    "wof:lastmodified":1695886650,
     "wof:name":"Lukala",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/990/7/1108799907.geojson
+++ b/data/110/879/990/7/1108799907.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.166437,
-    "geom:area_square_m":2013156230.62675,
+    "geom:area_square_m":2013156349.785938,
     "geom:bbox":"16.513937,-12.25225,17.075456,-11.694368",
     "geom:latitude":-11.986166,
     "geom:longitude":16.808845,
@@ -103,9 +103,10 @@
         "hasc:id":"AO.BI.CN",
         "wd:id":"Q660412"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985417,
-    "wof:geomhash":"8c596ced7477a13fd05b245512a438c3",
+    "wof:geomhash":"dda8a25730ad403af3221a3df2069e08",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108799907,
-    "wof:lastmodified":1690850249,
+    "wof:lastmodified":1695886649,
     "wof:name":"Kunhinga",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/990/9/1108799909.geojson
+++ b/data/110/879/990/9/1108799909.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.912362,
-    "geom:area_square_m":23322575680.168934,
+    "geom:area_square_m":23322575159.91291,
     "geom:bbox":"19.589639,-10.664062,21.94,-8.334017",
     "geom:latitude":-9.480478,
     "geom:longitude":20.689116,
@@ -217,9 +217,10 @@
         "hasc:id":"AO.LS.SA",
         "wd:id":"Q635017"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985418,
-    "wof:geomhash":"eaed93f3e6137876c2f9134858f5cb18",
+    "wof:geomhash":"5626bbd547785ca7be952dd28df14e41",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -229,7 +230,7 @@
         }
     ],
     "wof:id":1108799909,
-    "wof:lastmodified":1690850249,
+    "wof:lastmodified":1695886065,
     "wof:name":"Saurimo",
     "wof:parent_id":85667651,
     "wof:placetype":"county",

--- a/data/110/879/991/1/1108799911.geojson
+++ b/data/110/879/991/1/1108799911.geojson
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"AO.LU.SZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985419,
-    "wof:geomhash":"edc70423efc68e8198c78e1b6afebaba",
+    "wof:geomhash":"09bd92e8b57358fceabe80ed641891e9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1108799911,
-    "wof:lastmodified":1566586685,
+    "wof:lastmodified":1695886648,
     "wof:name":"Sambizanga",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/991/3/1108799913.geojson
+++ b/data/110/879/991/3/1108799913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.687887,
-    "geom:area_square_m":8183035000.784503,
+    "geom:area_square_m":8183034813.653824,
     "geom:bbox":"13.49382,-16.367877,14.876577,-15.29332",
     "geom:latitude":-15.834543,
     "geom:longitude":14.059624,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.HL.CG",
         "wd:id":"Q2342418"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985420,
-    "wof:geomhash":"85a3575e75b0f7646924bf48c5624a3c",
+    "wof:geomhash":"a4038f391876142e661c6e178c0f83a0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799913,
-    "wof:lastmodified":1690850246,
+    "wof:lastmodified":1695886649,
     "wof:name":"Gambos",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/991/5/1108799915.geojson
+++ b/data/110/879/991/5/1108799915.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.23922,
-    "geom:area_square_m":2896079178.20981,
+    "geom:area_square_m":2896079157.103021,
     "geom:bbox":"20.159167,-12.015853,20.921767,-11.52168",
     "geom:latitude":-11.743227,
     "geom:longitude":20.581917,
@@ -97,9 +97,10 @@
         "hasc:id":"AO.MX.LE",
         "wd:id":"Q1620853"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985421,
-    "wof:geomhash":"a455ea8ec9b960850382e4741257aedf",
+    "wof:geomhash":"9a39876e76c0b4d4d2c73cf81fb26b56",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -109,7 +110,7 @@
         }
     ],
     "wof:id":1108799915,
-    "wof:lastmodified":1690850246,
+    "wof:lastmodified":1695886649,
     "wof:name":"Leua",
     "wof:parent_id":85667711,
     "wof:placetype":"county",

--- a/data/110/879/991/7/1108799917.geojson
+++ b/data/110/879/991/7/1108799917.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.353457,
-    "geom:area_square_m":4253844071.312003,
+    "geom:area_square_m":4253844075.938491,
     "geom:bbox":"15.287614,-13.765044,15.924828,-12.720321",
     "geom:latitude":-13.268992,
     "geom:longitude":15.573374,
@@ -133,9 +133,10 @@
         "hasc:id":"AO.HM.CA",
         "wd:id":"Q1052090"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985422,
-    "wof:geomhash":"b54fe52de937ed28f72bb56ecfdda1bb",
+    "wof:geomhash":"9b891eafaf7c2dcb336a8b58a003780c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1108799917,
-    "wof:lastmodified":1690850246,
+    "wof:lastmodified":1695886648,
     "wof:name":"Kaala",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/992/1/1108799921.geojson
+++ b/data/110/879/992/1/1108799921.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.581522,
-    "geom:area_square_m":7034792276.555296,
+    "geom:area_square_m":7034791953.856276,
     "geom:bbox":"15.359483,-12.397745,16.538938,-11.439929",
     "geom:latitude":-11.948435,
     "geom:longitude":15.852117,
@@ -130,9 +130,10 @@
         "hasc:id":"AO.HM.BA",
         "wd:id":"Q1619845"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985423,
-    "wof:geomhash":"b272a45e1ce8efbe4086085ea0e7e752",
+    "wof:geomhash":"cb9c9f8b435aa821e843859b86723ef9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -142,7 +143,7 @@
         }
     ],
     "wof:id":1108799921,
-    "wof:lastmodified":1690850264,
+    "wof:lastmodified":1695886655,
     "wof:name":"Bailundo",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/992/3/1108799923.geojson
+++ b/data/110/879/992/3/1108799923.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.928074,
-    "geom:area_square_m":10970007192.209635,
+    "geom:area_square_m":10970007199.717108,
     "geom:bbox":"15.364411,-17.390944,17.318479,-16.556566",
     "geom:latitude":-17.073178,
     "geom:longitude":16.610816,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.CU.NA",
         "wd:id":"Q1619295"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985424,
-    "wof:geomhash":"890de19ab9a64f94965dedbfbe6ec2cc",
+    "wof:geomhash":"5ef9df3c4b026766ca116fe6e85a8420",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799923,
-    "wof:lastmodified":1690850264,
+    "wof:lastmodified":1695886655,
     "wof:name":"Namakunde",
     "wof:parent_id":85667701,
     "wof:placetype":"county",

--- a/data/110/879/992/5/1108799925.geojson
+++ b/data/110/879/992/5/1108799925.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.782893,
-    "geom:area_square_m":9588590826.197441,
+    "geom:area_square_m":9588590848.607559,
     "geom:bbox":"21.113016,-8.579414,21.917499,-7.280833",
     "geom:latitude":-7.899053,
     "geom:longitude":21.498091,
@@ -103,9 +103,10 @@
         "hasc:id":"AO.LN.CB",
         "wd:id":"Q3651209"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985425,
-    "wof:geomhash":"0227619968abb6e385a3db37fef512aa",
+    "wof:geomhash":"b0edcf1471661028675f85b7167e5249",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -115,7 +116,7 @@
         }
     ],
     "wof:id":1108799925,
-    "wof:lastmodified":1690850264,
+    "wof:lastmodified":1695886655,
     "wof:name":"Kambulo",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/110/879/992/7/1108799927.geojson
+++ b/data/110/879/992/7/1108799927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.155853,
-    "geom:area_square_m":1903896915.82344,
+    "geom:area_square_m":1903896849.629485,
     "geom:bbox":"14.064225,-9.23841,14.626415,-8.584518",
     "geom:latitude":-8.908889,
     "geom:longitude":14.348807,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.BO.PA",
         "wd:id":"Q2338202"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985427,
-    "wof:geomhash":"c710f84e8973b01cb0825d5e7bddd1d4",
+    "wof:geomhash":"9ed57a17aca1b6b42c7d494f10677779",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799927,
-    "wof:lastmodified":1690850263,
+    "wof:lastmodified":1695886655,
     "wof:name":"Pango-Aluquem",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/992/9/1108799929.geojson
+++ b/data/110/879/992/9/1108799929.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.738972,
-    "geom:area_square_m":8823664677.651644,
+    "geom:area_square_m":8823664511.022932,
     "geom:bbox":"14.140192,-15.693083,14.941349,-14.399724",
     "geom:latitude":-15.057133,
     "geom:longitude":14.56095,
@@ -115,9 +115,10 @@
         "hasc:id":"AO.HL.QP",
         "wd:id":"Q774789"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985428,
-    "wof:geomhash":"e8b03cf84d12f7ca1e1052050acd86ba",
+    "wof:geomhash":"5a7a08fda3608c82196d7dabd574ce25",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108799929,
-    "wof:lastmodified":1690850263,
+    "wof:lastmodified":1695886655,
     "wof:name":"Tchipungo",
     "wof:parent_id":85667707,
     "wof:placetype":"county",

--- a/data/110/879/993/1/1108799931.geojson
+++ b/data/110/879/993/1/1108799931.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.241082,
-    "geom:area_square_m":2906685425.037915,
+    "geom:area_square_m":2906685501.660899,
     "geom:bbox":"15.569946,-13.413258,15.986984,-12.240162",
     "geom:latitude":-12.81888,
     "geom:longitude":15.796837,
@@ -76,9 +76,10 @@
         "hasc:id":"AO.HM.HU",
         "wd:id":"Q3787366"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985429,
-    "wof:geomhash":"1b7282322590e6aaaaec360246453512",
+    "wof:geomhash":"fdec0d5fec9a13c75d8c8b6a6b96265f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108799931,
-    "wof:lastmodified":1690850265,
+    "wof:lastmodified":1695886066,
     "wof:name":"Huambo",
     "wof:parent_id":85667705,
     "wof:placetype":"county",

--- a/data/110/879/993/3/1108799933.geojson
+++ b/data/110/879/993/3/1108799933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.318936,
-    "geom:area_square_m":3905878399.086702,
+    "geom:area_square_m":3905878344.585875,
     "geom:bbox":"13.086407,-8.324522,13.855794,-7.62127",
     "geom:latitude":-7.94081,
     "geom:longitude":13.498228,
@@ -112,9 +112,10 @@
         "hasc:id":"AO.BO.AM",
         "wd:id":"Q3613801"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985430,
-    "wof:geomhash":"3b9b4158d6f5d29016cd644bbdb444cf",
+    "wof:geomhash":"ceedd4482a5077de39a570b6e24a76d7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -124,7 +125,7 @@
         }
     ],
     "wof:id":1108799933,
-    "wof:lastmodified":1690850265,
+    "wof:lastmodified":1695886067,
     "wof:name":"Ambriz",
     "wof:parent_id":85667657,
     "wof:placetype":"county",

--- a/data/110/879/993/5/1108799935.geojson
+++ b/data/110/879/993/5/1108799935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001261,
-    "geom:area_square_m":15406135.29347,
+    "geom:area_square_m":15406077.371615,
     "geom:bbox":"13.212251,-8.830798,13.274995,-8.761278",
     "geom:latitude":-8.80585,
     "geom:longitude":13.242673,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"AO.LU.IN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985431,
-    "wof:geomhash":"71f781133a165f5cf7f13343e5ef677b",
+    "wof:geomhash":"eaa634c957caeb342c93ac509f3f49ae",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1108799935,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Ingombota",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/993/9/1108799939.geojson
+++ b/data/110/879/993/9/1108799939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.268598,
-    "geom:area_square_m":3287112154.364472,
+    "geom:area_square_m":3287112524.864434,
     "geom:bbox":"15.17106,-8.567202,15.83161,-7.932561",
     "geom:latitude":-8.22222,
     "geom:longitude":15.512988,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.CN.AM",
         "wd:id":"Q1619833"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985432,
-    "wof:geomhash":"26f41e59c44a40fddf768db7ad2cc16f",
+    "wof:geomhash":"ef4db2d3e300bdc09ca87493e60fd06e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799939,
-    "wof:lastmodified":1690850265,
+    "wof:lastmodified":1695886656,
     "wof:name":"Ambaca",
     "wof:parent_id":85667659,
     "wof:placetype":"county",

--- a/data/110/879/994/1/1108799941.geojson
+++ b/data/110/879/994/1/1108799941.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043182,
-    "geom:area_square_m":527121096.409845,
+    "geom:area_square_m":527121332.430954,
     "geom:bbox":"13.017242,-9.342916,13.304931,-9.041004",
     "geom:latitude":-9.173835,
     "geom:longitude":13.166873,
@@ -47,7 +47,7 @@
     "wof:concordances":{},
     "wof:country":"AO",
     "wof:created":1483985433,
-    "wof:geomhash":"f51a6c5568e85e5299fa6a0b80df7011",
+    "wof:geomhash":"b6e530ca105acb2f964c53bade5966a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -57,7 +57,7 @@
         }
     ],
     "wof:id":1108799941,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695887498,
     "wof:name":"Barra Do Cuanza",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/994/3/1108799943.geojson
+++ b/data/110/879/994/3/1108799943.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.313873,
-    "geom:area_square_m":3814536071.700026,
+    "geom:area_square_m":3814535778.834897,
     "geom:bbox":"13.494737,-11.021039,14.277872,-10.208723",
     "geom:latitude":-10.625469,
     "geom:longitude":13.939539,
@@ -154,9 +154,10 @@
         "hasc:id":"AO.CS.PA",
         "wd:id":"Q1018592"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985434,
-    "wof:geomhash":"b33ee7e99aca580f5ab61f605873ba20",
+    "wof:geomhash":"d5c9a477be83be4162ad86e56390dd6f",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -166,7 +167,7 @@
         }
     ],
     "wof:id":1108799943,
-    "wof:lastmodified":1690850268,
+    "wof:lastmodified":1695886657,
     "wof:name":"Porto Amboim",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/994/5/1108799945.geojson
+++ b/data/110/879/994/5/1108799945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.046978,
-    "geom:area_square_m":574084556.134049,
+    "geom:area_square_m":574084497.138871,
     "geom:bbox":"13.305869,-8.887506,13.635635,-8.633765",
     "geom:latitude":-8.779713,
     "geom:longitude":13.477576,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.LU.CC",
         "wd:id":"Q1005770"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985435,
-    "wof:geomhash":"01ff94809947c12c7ebf384476512b96",
+    "wof:geomhash":"462c598ea2994183cf23b397b5e18ceb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799945,
-    "wof:lastmodified":1690850268,
+    "wof:lastmodified":1695886657,
     "wof:name":"Cacuaco",
     "wof:parent_id":85667669,
     "wof:placetype":"county",

--- a/data/110/879/994/7/1108799947.geojson
+++ b/data/110/879/994/7/1108799947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.637788,
-    "geom:area_square_m":19693752477.41803,
+    "geom:area_square_m":19693752991.715111,
     "geom:bbox":"16.479441,-14.311489,18.095138,-12.849264",
     "geom:latitude":-13.474688,
     "geom:longitude":17.229896,
@@ -115,9 +115,10 @@
         "hasc:id":"AO.BI.CH",
         "wd:id":"Q2342438"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985436,
-    "wof:geomhash":"8be4ef4728d20c8bbb08ec7df1878abb",
+    "wof:geomhash":"cc36e74331849879e400ab4e217793ff",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -127,7 +128,7 @@
         }
     ],
     "wof:id":1108799947,
-    "wof:lastmodified":1690850268,
+    "wof:lastmodified":1695886657,
     "wof:name":"Chitembo",
     "wof:parent_id":85667687,
     "wof:placetype":"county",

--- a/data/110/879/994/9/1108799949.geojson
+++ b/data/110/879/994/9/1108799949.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.162504,
-    "geom:area_square_m":1975602045.276608,
+    "geom:area_square_m":1975602059.309729,
     "geom:bbox":"14.068246,-10.774494,14.610095,-10.271963",
     "geom:latitude":-10.522312,
     "geom:longitude":14.368357,
@@ -100,9 +100,10 @@
         "hasc:id":"AO.CS.QL",
         "wd:id":"Q1619913"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985437,
-    "wof:geomhash":"8aa126eb9ce185ec0bfe3e3d7b867fbb",
+    "wof:geomhash":"c9c53174aa20a95c847266efdf468e87",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -112,7 +113,7 @@
         }
     ],
     "wof:id":1108799949,
-    "wof:lastmodified":1690850267,
+    "wof:lastmodified":1695886657,
     "wof:name":"Kilenda",
     "wof:parent_id":85667665,
     "wof:placetype":"county",

--- a/data/110/879/995/1/1108799951.geojson
+++ b/data/110/879/995/1/1108799951.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.460853,
-    "geom:area_square_m":5655381486.647009,
+    "geom:area_square_m":5655381486.647088,
     "geom:bbox":"13.8074179256,-7.52543130452,14.7477369777,-6.57753747308",
     "geom:latitude":-7.052368,
     "geom:longitude":14.2782,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"AO.UI.BE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985438,
-    "wof:geomhash":"23aa662b370940539663a1a23657e5da",
+    "wof:geomhash":"c44a8b1797794efd9f3e113f4695a562",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1108799951,
-    "wof:lastmodified":1566586704,
+    "wof:lastmodified":1695886654,
     "wof:name":"Bembe",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/995/3/1108799953.geojson
+++ b/data/110/879/995/3/1108799953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.720619,
-    "geom:area_square_m":8617709635.521334,
+    "geom:area_square_m":8617710024.209066,
     "geom:bbox":"12.024026,-15.595068,12.90314,-13.52688",
     "geom:latitude":-14.721051,
     "geom:longitude":12.459482,
@@ -76,9 +76,10 @@
         "hasc:id":"AO.NA.NA",
         "wd:id":"Q3870058"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985441,
-    "wof:geomhash":"20d4d944dc906524af8353c00deb9c9f",
+    "wof:geomhash":"1da7097f044be6270d87065b4f4aefe0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1108799953,
-    "wof:lastmodified":1690850261,
+    "wof:lastmodified":1695886067,
     "wof:name":"Namibe",
     "wof:parent_id":85667717,
     "wof:placetype":"county",

--- a/data/110/879/995/7/1108799957.geojson
+++ b/data/110/879/995/7/1108799957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.619305,
-    "geom:area_square_m":7614206816.816648,
+    "geom:area_square_m":7614206106.416634,
     "geom:bbox":"14.768831,-6.642691,16.438222,-5.859311",
     "geom:latitude":-6.115527,
     "geom:longitude":15.505951,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.UI.ZO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985443,
-    "wof:geomhash":"f6cf8e30c648a889298705d6e3eb3709",
+    "wof:geomhash":"b2baf9203a721aad00878e4d8fc1d9fa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799957,
-    "wof:lastmodified":1627521476,
+    "wof:lastmodified":1695886721,
     "wof:name":"Maquela do Zombo",
     "wof:parent_id":85667673,
     "wof:placetype":"county",

--- a/data/110/879/995/9/1108799959.geojson
+++ b/data/110/879/995/9/1108799959.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.19742,
-    "geom:area_square_m":2380947791.474191,
+    "geom:area_square_m":2380949029.886664,
     "geom:bbox":"13.263695,-13.116877,13.956553,-12.508532",
     "geom:latitude":-12.74944,
     "geom:longitude":13.61249,
@@ -85,9 +85,10 @@
         "hasc:id":"AO.BG.BE",
         "wd:id":"Q3638179"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985444,
-    "wof:geomhash":"8bfd7ac89ebeb8c3c5165cc90093d103",
+    "wof:geomhash":"d2422159ea0fc838c4d2d91261e91f6d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -97,7 +98,7 @@
         }
     ],
     "wof:id":1108799959,
-    "wof:lastmodified":1690850261,
+    "wof:lastmodified":1695886067,
     "wof:name":"Benguela",
     "wof:parent_id":85667691,
     "wof:placetype":"county",

--- a/data/110/879/996/1/1108799961.geojson
+++ b/data/110/879/996/1/1108799961.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.965484,
-    "geom:area_square_m":23448812131.520184,
+    "geom:area_square_m":23448811950.682621,
     "geom:bbox":"17.065299,-16.631102,18.315756,-13.673823",
     "geom:latitude":-15.224183,
     "geom:longitude":17.750499,
@@ -220,9 +220,10 @@
         "hasc:id":"AO.CC.ME",
         "wd:id":"Q818731"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985445,
-    "wof:geomhash":"71990a2f0fa58726420af788c80b71f8",
+    "wof:geomhash":"15fe12c081e682e9c73da1e7d0e391bb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -232,7 +233,7 @@
         }
     ],
     "wof:id":1108799961,
-    "wof:lastmodified":1690850246,
+    "wof:lastmodified":1695886065,
     "wof:name":"Menongue",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/996/3/1108799963.geojson
+++ b/data/110/879/996/3/1108799963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.713091,
-    "geom:area_square_m":44104745226.185356,
+    "geom:area_square_m":44104745822.734261,
     "geom:bbox":"19.104646,-17.455119,21.536603,-14.831437",
     "geom:latitude":-16.122498,
     "geom:longitude":20.299436,
@@ -145,9 +145,10 @@
         "hasc:id":"AO.CC.MA",
         "wd:id":"Q1620590"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985447,
-    "wof:geomhash":"a9bad3a1e71acb83b625a1c55ceb5888",
+    "wof:geomhash":"eee98eaeb193eccba54816d95e962eaa",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -157,7 +158,7 @@
         }
     ],
     "wof:id":1108799963,
-    "wof:lastmodified":1690850247,
+    "wof:lastmodified":1695886065,
     "wof:name":"Mavinga",
     "wof:parent_id":85667695,
     "wof:placetype":"county",

--- a/data/110/879/996/5/1108799965.geojson
+++ b/data/110/879/996/5/1108799965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.801908,
-    "geom:area_square_m":9772275324.6695,
+    "geom:area_square_m":9772275093.797413,
     "geom:bbox":"18.228317,-10.410166,19.444699,-9.088332",
     "geom:latitude":-9.753418,
     "geom:longitude":18.848568,
@@ -57,9 +57,10 @@
     "wof:concordances":{
         "hasc:id":"AO.LN.CP"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"AO",
     "wof:created":1483985448,
-    "wof:geomhash":"e9ae1ab94a54121f83a2af7f897c37a6",
+    "wof:geomhash":"09efe9207ce93e4c6087e6b833997800",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -69,7 +70,7 @@
         }
     ],
     "wof:id":1108799965,
-    "wof:lastmodified":1627521475,
+    "wof:lastmodified":1695886720,
     "wof:name":"Kapenda Kamulemba",
     "wof:parent_id":85667645,
     "wof:placetype":"county",

--- a/data/856/322/81/85632281.geojson
+++ b/data/856/322/81/85632281.geojson
@@ -1194,6 +1194,7 @@
         "hasc:id":"AO",
         "icao:code":"D2",
         "ioc:id":"ANG",
+        "iso:code":"AO",
         "itu:id":"AGL",
         "m49:code":"024",
         "marc:id":"ao",
@@ -1207,6 +1208,7 @@
         "wk:page":"Angola",
         "wmo:id":"AN"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:country_alpha3":"AGO",
     "wof:geom_alt":[
@@ -1228,7 +1230,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1694639554,
+    "wof:lastmodified":1695881213,
     "wof:name":"Angola",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/676/45/85667645.geojson
+++ b/data/856/676/45/85667645.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.859217,
-    "geom:area_square_m":108288153469.471161,
+    "geom:area_square_m":108288152659.496399,
     "geom:bbox":"17.335825,-10.669135,21.917499,-6.913889",
     "geom:latitude":-8.650944,
     "geom:longitude":19.49551,
@@ -332,17 +332,19 @@
         "gn:id":145702,
         "gp:id":2344671,
         "hasc:id":"AO.LN",
+        "iso:code":"AO-LNO",
         "iso:id":"AO-LNO",
         "qs_pg:id":209009,
         "unlc:id":"AO-LNO",
         "wd:id":"Q214221",
         "wk:page":"Lunda Norte Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"0ca45aabc6dfbb85b59451798a5e1a3a",
+    "wof:geomhash":"4b104868476ff7af549703cb1dc52193",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -357,7 +359,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850236,
+    "wof:lastmodified":1695884935,
     "wof:name":"Lunda Norte",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/51/85667651.geojson
+++ b/data/856/676/51/85667651.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.382864,
-    "geom:area_square_m":77676788075.487839,
+    "geom:area_square_m":77676788127.315994,
     "geom:bbox":"18.47982,-11.477896,22.315,-8.334017",
     "geom:latitude":-10.18015,
     "geom:longitude":20.652356,
@@ -336,17 +336,19 @@
         "gn:id":145701,
         "gp:id":2344672,
         "hasc:id":"AO.LS",
+        "iso:code":"AO-LSU",
         "iso:id":"AO-LSU",
         "qs_pg:id":984064,
         "unlc:id":"AO-LSU",
         "wd:id":"Q219648",
         "wk:page":"Lunda Sul Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"4ffb957e266d3e7aec937d343ffc2d1e",
+    "wof:geomhash":"71d5bf67c9a4eb87df4a0aed91379f85",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850236,
+    "wof:lastmodified":1695884936,
     "wof:name":"Lunda Sul",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/53/85667653.geojson
+++ b/data/856/676/53/85667653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.767945,
-    "geom:area_square_m":82526783894.399643,
+    "geom:area_square_m":82526784790.169327,
     "geom:bbox":"15.113665,-11.73238,18.85319,-7.318705",
     "geom:latitude":-9.490122,
     "geom:longitude":16.962231,
@@ -323,16 +323,18 @@
         "gn:id":2239858,
         "gp:id":2344666,
         "hasc:id":"AO.ML",
+        "iso:code":"AO-MAL",
         "iso:id":"AO-MAL",
         "qs_pg:id":318267,
         "wd:id":"Q219072",
         "wk:page":"Malanje Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"87617457888e7c36a190dca4666a6ed1",
+    "wof:geomhash":"cb319d995ceeaa3d31d24fb03be9db13",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -347,7 +349,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850238,
+    "wof:lastmodified":1695884936,
     "wof:name":"Malanje",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/57/85667657.geojson
+++ b/data/856/676/57/85667657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.823947,
-    "geom:area_square_m":34487584595.788055,
+    "geom:area_square_m":34487584241.227623,
     "geom:bbox":"13.086407,-10.438715,14.731279,-7.62127",
     "geom:latitude":-8.975402,
     "geom:longitude":13.880933,
@@ -341,17 +341,19 @@
         "gn:id":2243598,
         "gp:id":2344673,
         "hasc:id":"AO.BO",
+        "iso:code":"AO-BGO",
         "iso:id":"AO-BGO",
         "qs_pg:id":423547,
         "unlc:id":"AO-BGO",
         "wd:id":"Q191299",
         "wk:page":"Bengo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"6b269582a7dbe0b66a526ea30a3ff189",
+    "wof:geomhash":"c7526f0afde6f68264c4e28a172c442b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -366,7 +368,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850235,
+    "wof:lastmodified":1695884935,
     "wof:name":"Bengo",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/59/85667659.geojson
+++ b/data/856/676/59/85667659.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.961398,
-    "geom:area_square_m":23960542747.272038,
+    "geom:area_square_m":23960543368.051655,
     "geom:bbox":"14.064225,-9.782211,15.83161,-7.932561",
     "geom:latitude":-8.896945,
     "geom:longitude":14.947477,
@@ -333,16 +333,18 @@
         "gn:id":2241660,
         "gp:id":2344660,
         "hasc:id":"AO.CN",
+        "iso:code":"AO-CNO",
         "iso:id":"AO-CNO",
         "qs_pg:id":984063,
         "wd:id":"Q216834",
         "wk:page":"Cuanza Norte Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cea9c1a8205c0aecf24690f56a6fc294",
+    "wof:geomhash":"e339da02a7f690b30e7f3d534320d454",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -357,7 +359,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850235,
+    "wof:lastmodified":1695884935,
     "wof:name":"Cuanza Norte",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/65/85667665.geojson
+++ b/data/856/676/65/85667665.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.57748,
-    "geom:area_square_m":55591445898.492973,
+    "geom:area_square_m":55591446088.307266,
     "geom:bbox":"13.494737,-12.205326,16.612919,-9.676496",
     "geom:latitude":-10.823999,
     "geom:longitude":15.044656,
@@ -337,16 +337,18 @@
         "gn:id":3349234,
         "gp:id":2344661,
         "hasc:id":"AO.CS",
+        "iso:code":"AO-CUS",
         "iso:id":"AO-CUS",
         "qs_pg:id":191300,
         "wd:id":"Q216998",
         "wk:page":"Cuanza Sul Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7e64582c5f3da828d719ea05cd2f426c",
+    "wof:geomhash":"a9775dd21169ee49429566a741559b60",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850238,
+    "wof:lastmodified":1695884936,
     "wof:name":"Cuanza Sul",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/69/85667669.geojson
+++ b/data/856/676/69/85667669.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.202701,
-    "geom:area_square_m":2475727159.616004,
+    "geom:area_square_m":2475727434.755483,
     "geom:bbox":"12.993722,-9.342916,13.635635,-8.633765",
     "geom:latitude":-8.97709,
     "geom:longitude":13.312179,
@@ -357,17 +357,19 @@
         "gn:id":2240444,
         "gp:id":2344665,
         "hasc:id":"AO.LU",
+        "iso:code":"AO-LUA",
         "iso:id":"AO-LUA",
         "qs_pg:id":1222194,
         "unlc:id":"AO-LUA",
         "wd:id":"Q190066",
         "wk:page":"Luanda Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"683e845c4e803f1327c143df9d4acee2",
+    "wof:geomhash":"9b0009c63c4b92e0491fac44ce67c8e7",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -382,7 +384,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850236,
+    "wof:lastmodified":1695884935,
     "wof:name":"Luanda",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/73/85667673.geojson
+++ b/data/856/676/73/85667673.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.064906,
-    "geom:area_square_m":62155464597.724274,
+    "geom:area_square_m":62155463706.029861,
     "geom:bbox":"13.807418,-8.410006,17.109267,-5.843677",
     "geom:latitude":-7.02131,
     "geom:longitude":15.472157,
@@ -333,17 +333,19 @@
         "gn:id":2236566,
         "gp:id":2344669,
         "hasc:id":"AO.UI",
+        "iso:code":"AO-UIG",
         "iso:id":"AO-UIG",
         "qs_pg:id":1142804,
         "unlc:id":"AO-UIG",
         "wd:id":"Q216972",
         "wk:page":"U\u00edge Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7dc740f0095567e0b05654db3319247b",
+    "wof:geomhash":"474a47202f495d73ff274f2aaebe0f28",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -358,7 +360,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850237,
+    "wof:lastmodified":1695884479,
     "wof:name":"U\u00edge",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/77/85667677.geojson
+++ b/data/856/676/77/85667677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.00541,
-    "geom:area_square_m":36914498384.35833,
+    "geom:area_square_m":36914499529.294434,
     "geom:bbox":"12.272861,-7.800718,14.985227,-5.832283",
     "geom:latitude":-6.604749,
     "geom:longitude":13.565652,
@@ -335,6 +335,7 @@
         "gn:id":2236355,
         "gp:id":2344670,
         "hasc:id":"AO.ZA",
+        "iso:code":"AO-ZAI",
         "iso:id":"AO-ZAI",
         "loc:id":"n80061025",
         "qs_pg:id":1083786,
@@ -342,11 +343,12 @@
         "wd:id":"Q196674",
         "wk:page":"Zaire Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"ea7e9442afdf0e052c9bd1d3a3586ae1",
+    "wof:geomhash":"615695cb5f880af889d0e2a7b031b6b4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850239,
+    "wof:lastmodified":1695884936,
     "wof:name":"Zaire",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/83/85667683.geojson
+++ b/data/856/676/83/85667683.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.572781,
-    "geom:area_square_m":7054893684.402952,
+    "geom:area_square_m":7054893351.563952,
     "geom:bbox":"12.005028,-5.774131,13.102885,-4.387944",
     "geom:latitude":-5.052604,
     "geom:longitude":12.466507,
@@ -379,17 +379,19 @@
         "gn:id":2243266,
         "gp:id":2344658,
         "hasc:id":"AO.CB",
+        "iso:code":"AO-CAB",
         "iso:id":"AO-CAB",
         "qs_pg:id":239498,
         "unlc:id":"AO-CAB",
         "wd:id":"Q168787",
         "wk:page":"Cabinda Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"74f997a415abe00f11f9264e6cc511ce",
+    "wof:geomhash":"c5bcac87b9afa7db1ad7ed400e2e6474",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -404,7 +406,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850238,
+    "wof:lastmodified":1695884366,
     "wof:name":"Cabinda",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/87/85667687.geojson
+++ b/data/856/676/87/85667687.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.997138,
-    "geom:area_square_m":72438817512.326935,
+    "geom:area_square_m":72438817500.400299,
     "geom:bbox":"15.75345,-14.311489,19.252095,-10.569328",
     "geom:latitude":-12.322836,
     "geom:longitude":17.366099,
@@ -340,17 +340,19 @@
         "gn:id":3351640,
         "gp:id":2344657,
         "hasc:id":"AO.BI",
+        "iso:code":"AO-BIE",
         "iso:id":"AO-BIE",
         "qs_pg:id":219498,
         "unlc:id":"AO-BIE",
         "wd:id":"Q213977",
         "wk:page":"Bi\u00e9 Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"a2d79a4847d8af91963b328c79e854fa",
+    "wof:geomhash":"b774d9c0ef200c2273a050656568451a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -365,7 +367,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850237,
+    "wof:lastmodified":1695884479,
     "wof:name":"Bi\u00e9",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/91/85667691.geojson
+++ b/data/856/676/91/85667691.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.287999,
-    "geom:area_square_m":39623992324.508888,
+    "geom:area_square_m":39623992893.055397,
     "geom:bbox":"12.522056,-13.873994,15.120286,-11.761812",
     "geom:latitude":-12.931767,
     "geom:longitude":13.990448,
@@ -344,17 +344,19 @@
         "gn:id":3351660,
         "gp:id":2344656,
         "hasc:id":"AO.BG",
+        "iso:code":"AO-BGU",
         "iso:id":"AO-BGU",
         "qs_pg:id":219493,
         "unlc:id":"AO-BGU",
         "wd:id":"Q212786",
         "wk:page":"Benguela Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bbb319d2ac156adc6cf587545caad55e",
+    "wof:geomhash":"1f63da211ca3b85cd60b70d142b72c6a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -369,7 +371,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850237,
+    "wof:lastmodified":1695884936,
     "wof:name":"Benguela",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/676/95/85667695.geojson
+++ b/data/856/676/95/85667695.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":16.888702,
-    "geom:area_square_m":200587740790.507477,
+    "geom:area_square_m":200587739539.979187,
     "geom:bbox":"16.471447,-18.039104,23.434232,-13.567188",
     "geom:latitude":-16.117869,
     "geom:longitude":19.5276,
@@ -345,16 +345,18 @@
         "gn:id":876337,
         "gp:id":2344659,
         "hasc:id":"AO.CC",
+        "iso:code":"AO-CCU",
         "iso:id":"AO-CCU",
         "qs_pg:id":984062,
         "wd:id":"Q215268",
         "wk:page":"Cuando Cubango Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b92e4a48ea1252aaf1be5b9ac74ec1fb",
+    "wof:geomhash":"cf4cae0b4567cf3c5cc19b1928041cee",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -369,7 +371,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850235,
+    "wof:lastmodified":1695884935,
     "wof:name":"Cuando Cubango",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/01/85667701.geojson
+++ b/data/856/677/01/85667701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.548113,
-    "geom:area_square_m":77629977931.596008,
+    "geom:area_square_m":77629977712.805969,
     "geom:bbox":"13.144903,-17.438843,17.429571,-15.14351",
     "geom:latitude":-16.502402,
     "geom:longitude":15.582198,
@@ -338,17 +338,19 @@
         "gn:id":3349096,
         "gp:id":2344662,
         "hasc:id":"AO.CU",
+        "iso:code":"AO-CNN",
         "iso:id":"AO-CNN",
         "qs_pg:id":191295,
         "unlc:id":"AO-CNN",
         "wd:id":"Q216987",
         "wk:page":"Cunene Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"1c84ed8b24efff88b3eec0f3a3801d77",
+    "wof:geomhash":"d26a96d683b5d03a14477c605e4d1c89",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -363,7 +365,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850241,
+    "wof:lastmodified":1695884936,
     "wof:name":"Cunene",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/05/85667705.geojson
+++ b/data/856/677/05/85667705.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.761236,
-    "geom:area_square_m":33323583255.132187,
+    "geom:area_square_m":33323582551.92807,
     "geom:bbox":"14.80356,-13.765044,16.594123,-11.434034",
     "geom:latitude":-12.567328,
     "geom:longitude":15.747076,
@@ -332,17 +332,19 @@
         "gn:id":3348310,
         "gp:id":2344663,
         "hasc:id":"AO.HM",
+        "iso:code":"AO-HUA",
         "iso:id":"AO-HUA",
         "qs_pg:id":1083783,
         "unlc:id":"AO-HUA",
         "wd:id":"Q218848",
         "wk:page":"Huambo Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"7200403d53764b115988c9819e42cd35",
+    "wof:geomhash":"59661434d4906f796cedb08c11e91dbe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -357,7 +359,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850239,
+    "wof:lastmodified":1695884936,
     "wof:name":"Huambo",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/07/85667707.geojson
+++ b/data/856/677/07/85667707.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.61033,
-    "geom:area_square_m":79042225390.051331,
+    "geom:area_square_m":79042224524.299713,
     "geom:bbox":"13.214118,-16.367877,16.748154,-13.331437",
     "geom:latitude":-14.740687,
     "geom:longitude":14.95353,
@@ -336,17 +336,19 @@
         "gn:id":3348303,
         "gp:id":2344664,
         "hasc:id":"AO.HL",
+        "iso:code":"AO-HUI",
         "iso:id":"AO-HUI",
         "qs_pg:id":1083784,
         "unlc:id":"AO-HUI",
         "wd:id":"Q214572",
         "wk:page":"Hu\u00edla Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"327a25ca65790a6087aede6f3fcc364d",
+    "wof:geomhash":"24131f6b5b9a535707cd80b15521f953",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -361,7 +363,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850240,
+    "wof:lastmodified":1695884479,
     "wof:name":"Hu\u00edla",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/11/85667711.geojson
+++ b/data/856/677/11/85667711.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":16.597751,
-    "geom:area_square_m":200034625478.00882,
+    "geom:area_square_m":200034626715.215698,
     "geom:bbox":"17.946408,-16.160437,24.084445,-10.587299",
     "geom:latitude":-12.877034,
     "geom:longitude":21.039158,
@@ -338,17 +338,19 @@
         "gn:id":875996,
         "gp:id":2344668,
         "hasc:id":"AO.MX",
+        "iso:code":"AO-MOX",
         "iso:id":"AO-MOX",
         "qs_pg:id":1142803,
         "unlc:id":"AO-MOX",
         "wd:id":"Q173988",
         "wk:page":"Moxico Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"c4a8ff62b0d00e81719cd26952e7b0a4",
+    "wof:geomhash":"0354d746b0335448be3f9aa606558e95",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -363,7 +365,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850239,
+    "wof:lastmodified":1695884937,
     "wof:name":"Moxico",
     "wof:parent_id":85632281,
     "wof:placetype":"region",

--- a/data/856/677/17/85667717.geojson
+++ b/data/856/677/17/85667717.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":4.886136,
-    "geom:area_square_m":58213404215.736885,
+    "geom:area_square_m":58213405083.162369,
     "geom:bbox":"11.674556,-17.273807,13.691323,-13.511118",
     "geom:latitude":-15.494337,
     "geom:longitude":12.729674,
@@ -329,17 +329,19 @@
         "gn:id":3347016,
         "gp:id":2344667,
         "hasc:id":"AO.NA",
+        "iso:code":"AO-NAM",
         "iso:id":"AO-NAM",
         "qs_pg:id":1083785,
         "unlc:id":"AO-NAM",
         "wd:id":"Q216819",
         "wk:page":"Namibe Province"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"AO",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"68d80a22b10525a5fc405e15a5297cba",
+    "wof:geomhash":"41df6f89c2b8c2f5575167ca7dfb1e61",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -354,7 +356,7 @@
     "wof:lang_x_spoken":[
         "por"
     ],
-    "wof:lastmodified":1690850240,
+    "wof:lastmodified":1695884937,
     "wof:name":"Namibe",
     "wof:parent_id":85632281,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.